### PR TITLE
fix-ish picture in conflicts

### DIFF
--- a/app/assets/stylesheets/pages/_calendar.scss
+++ b/app/assets/stylesheets/pages/_calendar.scss
@@ -2,45 +2,50 @@
   margin: 30px;
 }
 
-  .skeleton {
-
+.skeleton {
     width:inherit;
     height:inherit;
     margin: 0 auto;
 }
-  .fc-day-header {
+
+.fc-day-header {
     color: $gray;
     font-family: "Oswald";
     font-size: 20px;
-  }
-  .fc th, .fc td  {
+}
+
+.fc th, .fc td  {
     border-style: none;
     padding: 2px;
     border-width: 3px;
-  }
-  /* border des events*/
-  .fc-time-grid-event {
+}
+
+/* border des events*/
+.fc-time-grid-event {
     border-radius: 10px;
     border-width:0px;
     box-shadow: 0px 0px 3.5px -1px white inset;
     padding:2px;
     padding-top: 7px;
     padding: 3px;
-  }
-  /* axe y*/
-  .fc-axis .fc-time .fc-widget-content {
-    color: $gray;
-    font-family: "Oswald";
-    font-weight: 400;
-  }
-  /*nom du role dans l'event*/
-  .fc-title{
-   font-family: "Robot";
-   font-size: 12px;
-   font-weight: 300;
- }
- /* active week/day button*/
- .fc-toolbar .fc-state-active, .fc-toolbar .ui-state-active{
+}
+
+/* axe y*/
+.fc-axis .fc-time .fc-widget-content {
+  color: $gray;
+  font-family: "Oswald";
+  font-weight: 400;
+}
+
+/*nom du role dans l'event*/
+.fc-title{
+ font-family: "Robot";
+ font-size: 12px;
+ font-weight: 300;
+}
+
+/* active week/day button*/
+.fc-toolbar .fc-state-active, .fc-toolbar .ui-state-active{
   color: white;
   font-family: "Robot";
 }
@@ -52,16 +57,18 @@
   text-shadow:none;
   background-image: none;
   width:70px;
-
 }
+
 .fc-button-group {
   font-family: "Robot";
   font-size: 13px;
 }
+
 /*bouton month*/
 .fc-month-button {
   width: 90px;
 }
+
 .fc-state-active {
   background-color: #191654;
   color: white;

--- a/app/assets/stylesheets/pages/_calendar.scss
+++ b/app/assets/stylesheets/pages/_calendar.scss
@@ -71,7 +71,3 @@
 .fc-agendaWeek-button {
   width: 90px;
 }
-/* ne pas montrer le title de l'event*/
-.fc-title {
-  display: none;
-}

--- a/app/views/plannings/conflicts.html.erb
+++ b/app/views/plannings/conflicts.html.erb
@@ -210,6 +210,7 @@
       eventRender: function(event, element) {
         console.log("here");
         console.log(event);
+        console.log(event.picture);
         element.find('.fc-title').html("<br/>" + "<img src= "+event.picture+" alt='' style='border-radius:60px;' >");
       }
     });

--- a/app/views/plannings/conflicts.html.erb
+++ b/app/views/plannings/conflicts.html.erb
@@ -208,9 +208,6 @@
       },
 
       eventRender: function(event, element) {
-        console.log("here");
-        console.log(event);
-        console.log(event.picture);
         element.find('.fc-title').html("<br/>" + "<img src= "+event.picture+" alt='' style='border-radius:60px;' >");
       }
     });

--- a/app/views/plannings/skeleton.html.erb
+++ b/app/views/plannings/skeleton.html.erb
@@ -27,9 +27,14 @@
     </div>
   </div>
 
-<!--  _______________________ CSS Calendar ___________________________ -->
+<!--  _______________________ CSS Calendar specific skeleton ___________________________ -->
 
-
+<style>
+  /* ne pas montrer le title de l'event*/
+ .fc-title {
+   display: none;
+ }
+</style>
 
 <!-- ___________________________ JS __________________________________ -->
 


### PR DESCRIPTION
- **problem =** pictures do not appear anymore on conflicts.html
- **cause =** to dry the code we placed all the calendar css in assets/pages/_calendar.scss. This code included `.fc-title { display: none; }`. In conflicts.html, this leads to unshow the picture since the picture is rendered in .fc-title via javascript:
```
      eventRender: function(event, element) {
        element.find('.fc-title').html("<br/>" + "<img src= "+event.picture+" alt='' style='border-radius:60px;' >");
      }
```
- **fix =** 3 steps =
1) leave scss in assets/pages/_calendar.scss

2) remove part in 1) concerning only skeleton.html
`.fc-title { display: none; }`

3) added 2) in a specific css part in skeleton.html

