### PR TITLE
Do not launch calcul from conflicts

### DIFF
--- a/app/controllers/plannings_controller.rb
+++ b/app/controllers/plannings_controller.rb
@@ -46,34 +46,22 @@ class PlanningsController < ApplicationController
 
     # Fake solution => le boss remplacera le no solution
     @user_solution = User.find_by(first_name: 'jean')
+    demo_method(@planning) if @planning.week_number == 37
 
-    if @planning.week_number == 37
-      demo_method(@planning)
-    # if planning is not complete and contains slots => generate solutions
-    elsif @planning.status != :complete && @slots.count.positive?
-      # => solution calculation
-      calcul_v1 = CalculSolutionV1.new(@planning)
-      calcul_v1.save
-      # @calcul_results = { :calcul_arrays, :test_possibilities, :solutions_array, :best_solution, :calculation_abstract }
-      @calcul_results = calcul_v1.perform
-      # @calcul_arrays = { slotgroups_array: @slotgroups_array, slots_array: @slots_array }
-      @calcul_arrays = @calcul_results[:calcul_arrays]
-      @test_possibilities = @calcul_results[:test_possibilities]
-      @solutions_array = @calcul_results[:solutions_array]
-      @best_solution = @calcul_results[:best_solution]
-      @calculation_abstract = @calcul_results[:calculation_abstract]
-      flash[:notice] = message_calculation_notice
-
-      #  affecter aux slots le user de la solution de ce planning au statut :validated
-      # identifier la solution validée
-      solution_instance = Solution.find_by(planning_id: @planning.id, calculsolutionv1_id: calcul_v1.id, status: :fresh)
+    # TODO_1: change this so that user_id is inherited from solution's effectivity
+    # TODO_2: change this so that solution_instance is determined according to Solution status
+    #  affecter aux slots le user de la solution de ce planning au statut :validated
+    # identifier la solution validée
+      solution_instance = Solution.select { |x| x.planning_id == @planning.id && x.status == "fresh" }.last
       @slots.each do |slot|
         # get solution_slot related to this slot
         the_solution_slot = SolutionSlot.select { |x| x.solution_id == solution_instance.id && x.slot_id == slot.id }
         slot.user_id = the_solution_slot.first.user_id
         slot.save
       end
-    end
+
+    # Display notice when displaying solution
+    flash[:notice] = message_calculation_notice(solution_instance.compute_solution)
 
     @slots.each do |slot|
       # Fake solution > def user id solution
@@ -219,15 +207,15 @@ class PlanningsController < ApplicationController
 
   # rubocop:disable LineLength
 
-  def message_calculation_notice
-    if @calculation_abstract.nil?
+  def message_calculation_notice(compute_solution)
+    if compute_solution.nb_solutions.nil?
       'non calculable car 0 solution'
     else
-      pourcent = (@calculation_abstract[:nb_iterations].fdiv(@calculation_abstract[:nb_possibilities_theory]) * 100).round(2)
-      "#{@calculation_abstract[:nb_solutions]} solutions trouvées,
-      dont #{@calculation_abstract[:nb_optimal_solutions]} optimales.
-       #{@calculation_abstract[:nb_iterations]} itérations effectuées parmi
-      #{@calculation_abstract[:nb_possibilities_theory]} possibilités théoriques,
+      pourcent = (compute_solution.nb_iterations.fdiv(compute_solution.nb_possibilities_theory) * 100).round(2)
+      "#{compute_solution.nb_solutions} solutions trouvées,
+      dont #{compute_solution.nb_optimal_solutions} optimales.
+       #{compute_solution.nb_iterations} itérations effectuées parmi
+      #{compute_solution.nb_possibilities_theory} possibilités théoriques,
       soit #{pourcent}
        pourcents du champs balayé"
     end

--- a/app/controllers/plannings_controller.rb
+++ b/app/controllers/plannings_controller.rb
@@ -60,9 +60,6 @@ class PlanningsController < ApplicationController
         slot.save
       end
 
-    # Display notice when displaying solution
-    flash[:notice] = message_calculation_notice(solution_instance.compute_solution)
-
     @slots.each do |slot|
       # Fake solution > def user id solution
       if !User.find(slot.user_id).profile_picture.nil?
@@ -207,18 +204,5 @@ class PlanningsController < ApplicationController
 
   # rubocop:disable LineLength
 
-  def message_calculation_notice(compute_solution)
-    if compute_solution.nb_solutions.nil?
-      'non calculable car 0 solution'
-    else
-      pourcent = (compute_solution.nb_iterations.fdiv(compute_solution.nb_possibilities_theory) * 100).round(2)
-      "#{compute_solution.nb_solutions} solutions trouvées,
-      dont #{compute_solution.nb_optimal_solutions} optimales.
-       #{compute_solution.nb_iterations} itérations effectuées parmi
-      #{compute_solution.nb_possibilities_theory} possibilités théoriques,
-      soit #{pourcent}
-       pourcents du champs balayé"
-    end
-  end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/jobs/compute_planning_solutions_job.rb
+++ b/app/jobs/compute_planning_solutions_job.rb
@@ -3,7 +3,8 @@ class ComputePlanningSolutionsJob < ApplicationJob
 
   def perform(planning, compute_solutions)
     calcul_instance = CalculSolutionV1.create(planning)
-    calcul_instance.perform
+    calcul_instance.compute_solution_id = compute_solutions.id
+    calcul_instance.perform(compute_solutions)
     compute_solutions.ready!
     rescue StandardError => e
     compute_solutions.error!

--- a/app/models/compute_solution.rb
+++ b/app/models/compute_solution.rb
@@ -2,11 +2,17 @@
 #
 # Table name: compute_solutions
 #
-#  id          :integer          not null, primary key
-#  status      :integer
-#  planning_id :integer
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
+#  id                      :integer          not null, primary key
+#  status                  :integer
+#  planning_id             :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  nb_solutions            :integer
+#  nb_optimal_solutions    :integer
+#  nb_iterations           :integer
+#  nb_possibilities_theory :integer
+#  calculation_length      :decimal(, )
+#  nb_cuts_within_tree     :integer
 #
 # Indexes
 #
@@ -19,11 +25,25 @@
 
 class ComputeSolution < ApplicationRecord
   belongs_to :planning
+  has_one :calcul_solution_v1
+  has_many :solutions
+
   enum status: [:pending, :ready, :error]
   before_create :default_status
 
+
   def default_status
     self.status = "pending"
+  end
+
+  def save_calculation_abstract(calculation_abstract)
+    # stores calculation properties.
+    self.nb_solutions = calculation_abstract[:nb_solutions]
+    self.nb_optimal_solutions = calculation_abstract[:nb_optimal_solutions]
+    self.nb_iterations = calculation_abstract[:nb_iterations]
+    self.nb_possibilities_theory = calculation_abstract[:nb_possibilities_theory]
+    self.calculation_length = calculation_abstract[:calculation_length]
+    self.nb_cuts_within_tree = calculation_abstract[:nb_cuts_within_tree]
   end
 
 end

--- a/app/models/compute_solution.rb
+++ b/app/models/compute_solution.rb
@@ -38,12 +38,12 @@ class ComputeSolution < ApplicationRecord
 
   def save_calculation_abstract(calculation_abstract)
     # stores calculation properties.
-    self.nb_solutions = calculation_abstract[:nb_solutions]
-    self.nb_optimal_solutions = calculation_abstract[:nb_optimal_solutions]
-    self.nb_iterations = calculation_abstract[:nb_iterations]
-    self.nb_possibilities_theory = calculation_abstract[:nb_possibilities_theory]
-    self.calculation_length = calculation_abstract[:calculation_length]
-    self.nb_cuts_within_tree = calculation_abstract[:nb_cuts_within_tree]
+    nb_solutions = calculation_abstract[:nb_solutions]
+    nb_optimal_solutions = calculation_abstract[:nb_optimal_solutions]
+    nb_iterations = calculation_abstract[:nb_iterations]
+    nb_possibilities_theory = calculation_abstract[:nb_possibilities_theory]
+    calculation_length = calculation_abstract[:calculation_length]
+    nb_cuts_within_tree = calculation_abstract[:nb_cuts_within_tree]
   end
 
 end

--- a/app/models/compute_solution.rb
+++ b/app/models/compute_solution.rb
@@ -25,7 +25,7 @@
 
 class ComputeSolution < ApplicationRecord
   belongs_to :planning
-  has_one :calcul_solution_v1
+  has_one :calcul_solution_v1, dependent: :destroy
   has_many :solutions
 
   enum status: [:pending, :ready, :error]

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -8,21 +8,26 @@
 #  nb_extra_hours      :integer
 #  status              :integer
 #  planning_id         :integer
+#  compute_solution_id :integer
 #
 # Indexes
 #
-#  index_solutions_on_planning_id  (planning_id)
+#  index_solutions_on_compute_solution_id  (compute_solution_id)
+#  index_solutions_on_planning_id          (planning_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (compute_solution_id => compute_solutions.id)
 #  fk_rails_...  (planning_id => plannings.id)
 #
 
 class Solution < ApplicationRecord
   belongs_to :planning
+  belongs_to :compute_solution
   has_many :solution_slots, dependent: :destroy
   has_many :users, through: :solution_slots
   has_many :slots, through: :solution_slots
+  has_one :calcul_solution_v1, through: :compute_solution
 
   validates :planning_id, presence: true
 

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -3,11 +3,11 @@
 # Table name: solutions
 #
 #  id                  :integer          not null, primary key
-#  calculsolutionv1_id :integer
 #  nb_overlaps         :integer
 #  nb_extra_hours      :integer
-#  status              :integer
 #  planning_id         :integer
+#  effectivity         :integer
+#  relevance           :integer
 #  compute_solution_id :integer
 #
 # Indexes

--- a/db/migrate/20180205122553_add_columns_to_compute_solutions.rb
+++ b/db/migrate/20180205122553_add_columns_to_compute_solutions.rb
@@ -1,0 +1,10 @@
+class AddColumnsToComputeSolutions < ActiveRecord::Migration[5.0]
+  def change
+    add_column :compute_solutions, :nb_solutions, :integer
+    add_column :compute_solutions, :nb_optimal_solutions, :integer
+    add_column :compute_solutions, :nb_iterations, :integer
+    add_column :compute_solutions, :nb_possibilities_theory, :integer
+    add_column :compute_solutions, :calculation_length, :decimal
+    add_column :compute_solutions, :nb_cuts_within_tree, :integer
+  end
+end

--- a/db/migrate/20180205141719_addforeignkeytocalculsolutionv1.rb
+++ b/db/migrate/20180205141719_addforeignkeytocalculsolutionv1.rb
@@ -1,0 +1,5 @@
+class Addforeignkeytocalculsolutionv1 < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :calcul_solution_v1s, :compute_solution, foreign_key: true, index: true
+  end
+end

--- a/db/migrate/20180205144331_add_foreign_key_to_solution.rb
+++ b/db/migrate/20180205144331_add_foreign_key_to_solution.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyToSolution < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :solutions, :compute_solution, foreign_key: true, index: true
+  end
+end

--- a/db/migrate/20180205161023_add_columns_to_solution.rb
+++ b/db/migrate/20180205161023_add_columns_to_solution.rb
@@ -1,0 +1,8 @@
+class AddColumnsToSolution < ActiveRecord::Migration[5.0]
+  def change
+    add_column :solutions, :effectivity, :integer
+    add_column :solutions, :relevance, :integer
+    remove_column :solutions, :status, :string
+    remove_column :solutions, :calculsolutionv1_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180205144331) do
+ActiveRecord::Schema.define(version: 20180205161023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,11 +112,11 @@ ActiveRecord::Schema.define(version: 20180205144331) do
   end
 
   create_table "solutions", force: :cascade do |t|
-    t.integer "calculsolutionv1_id"
     t.integer "nb_overlaps"
     t.integer "nb_extra_hours"
-    t.integer "status"
     t.integer "planning_id"
+    t.integer "effectivity"
+    t.integer "relevance"
     t.integer "compute_solution_id"
     t.index ["compute_solution_id"], name: "index_solutions_on_compute_solution_id", using: :btree
     t.index ["planning_id"], name: "index_solutions_on_planning_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171215141520) do
+ActiveRecord::Schema.define(version: 20180205144331) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,18 +31,26 @@ ActiveRecord::Schema.define(version: 20171215141520) do
   end
 
   create_table "calcul_solution_v1s", force: :cascade do |t|
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
     t.text     "slots_array"
     t.text     "slotgroups_array"
     t.text     "information"
+    t.integer  "compute_solution_id"
+    t.index ["compute_solution_id"], name: "index_calcul_solution_v1s_on_compute_solution_id", using: :btree
   end
 
   create_table "compute_solutions", force: :cascade do |t|
     t.integer  "status"
     t.integer  "planning_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+    t.integer  "nb_solutions"
+    t.integer  "nb_optimal_solutions"
+    t.integer  "nb_iterations"
+    t.integer  "nb_possibilities_theory"
+    t.decimal  "calculation_length"
+    t.integer  "nb_cuts_within_tree"
     t.index ["planning_id"], name: "index_compute_solutions_on_planning_id", using: :btree
   end
 
@@ -109,6 +117,8 @@ ActiveRecord::Schema.define(version: 20171215141520) do
     t.integer "nb_extra_hours"
     t.integer "status"
     t.integer "planning_id"
+    t.integer "compute_solution_id"
+    t.index ["compute_solution_id"], name: "index_solutions_on_compute_solution_id", using: :btree
     t.index ["planning_id"], name: "index_solutions_on_planning_id", using: :btree
   end
 
@@ -142,6 +152,7 @@ ActiveRecord::Schema.define(version: 20171215141520) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  add_foreign_key "calcul_solution_v1s", "compute_solutions"
   add_foreign_key "compute_solutions", "plannings"
   add_foreign_key "constraints", "users"
   add_foreign_key "role_users", "roles"
@@ -152,6 +163,7 @@ ActiveRecord::Schema.define(version: 20171215141520) do
   add_foreign_key "solution_slots", "slots"
   add_foreign_key "solution_slots", "solutions"
   add_foreign_key "solution_slots", "users"
+  add_foreign_key "solutions", "compute_solutions"
   add_foreign_key "solutions", "plannings"
   add_foreign_key "teams", "plannings"
   add_foreign_key "teams", "users"


### PR DESCRIPTION
goal : do not launch algo calcul from /conflicts

**1) model changes** 
1.1)  linked together models  solution + compute_solution + calculsolutionv1 =
- solution belongs to compute_solution
- compute_solution has_many solutions
- compute_solution has one calcul_solution_v1 (+dependent destroy)
- calculsolutionv1 belongs_to compute_solution
- solution has_one calculsolutionv1 through compute_solution

1.2) added columns to compute_solutions to store its caracteristics (:nb_solutions, :nb_optimal_solutions, :nb_possibilities_theory, :calculation_length, :nb_cuts_within_tree).
N.B. Those caracteristics are evaluated in CalculSolutionV1Service/GoFindSolutionsService.

**2) impacts in CalculSolutionV1**
We added an argument to the method perform `def perform(compute_solutions)` so that all the elements of the job can be linked together (see 1.1).

**3) impacts in PlanningsController**
- flash notice display = comes from the compute_solution caracteristics (see 1.2.)
 
**4) flash notice**
removed since its information is now available through the ComputeSolution instance.

