### PR TITLE
Kill user id in slots

### DIFF
--- a/app/controllers/plannings_controller.rb
+++ b/app/controllers/plannings_controller.rb
@@ -56,59 +56,53 @@ class PlanningsController < ApplicationController
       # identifier la solution validée
       solution_instance = @planning.solutions.chosen.last
       @slots.each do |slot|
-        # get solution_slot related to this slot
-        the_solution_slot = SolutionSlot.select { |x| x.solution_id == solution_instance.id && x.slot_id == slot.id }
-        slot.user_id = the_solution_slot.first.user_id
-        slot.save
+        solution_slot = solution_instance.solution_slots.select{|x| x.slot == slot }
+        # Fake solution > def user id solution
+        if !User.find(solution_slot.user_id).profile_picture.nil?
+          # picture du user
+          picture = 'http://res.cloudinary.com/dksqsr3pd/image/upload/c_fill,r_60,w_60/' + User.find(solution_slot.user_id).profile_picture.path
+        else
+          # point d'interrogation par defaut
+          picture = 'http://a398.idata.over-blog.com/60x60/3/91/14/12/novembre-2010/point-d-interrogation-bleu-ciel.jpg'
+        end
+
+        a = {
+          id:  slot.id,
+          start:  slot.start_at,
+          end: slot.end_at,
+          title: Role.find_by(id: slot.role_id).name, # nom du role
+          role_id: slot.role_id, # nom du role
+          created_at: slot.created_at,
+          updated_at: slot.updated_at,
+          color: Role.find_by(id: slot.role_id).role_color,
+          planning_id: slot.planning_id,
+          user_id: User.find(solution_slot.user_id).id,
+          picture: picture
+        }
+
+        picture_solution = 'http://res.cloudinary.com/dksqsr3pd/image/upload/c_fill,r_60,w_60/' + User.find_by(first_name: 'jean').profile_picture.path
+        user_id_solution = User.find_by(first_name: 'jean').id
+
+        b = {
+          id: slot.id,
+          start: slot.start_at,
+          end: slot.end_at,
+          title: Role.find_by(id: slot.role_id).name, # nom du role
+          role_id: slot.role_id, # nom du role
+          created_at: slot.created_at,
+          updated_at: slot.updated_at,
+          color: Role.find_by(id: slot.role_id).role_color,
+          planning_id: slot.planning_id,
+          user_id: user_id_solution,
+          picture: picture_solution
+        }
+        @slots_array << a
+        @slots_solution << if solution_slot.user_id == User.find_by(first_name: 'no solution').id
+                             b
+                           else
+                             a
+                           end
       end
-
-    @slots.each do |slot|
-      # Fake solution > def user id solution
-      if !User.find(slot.user_id).profile_picture.nil?
-        # picture du user
-        picture = 'http://res.cloudinary.com/dksqsr3pd/image/upload/c_fill,r_60,w_60/' + User.find(slot.user_id).profile_picture.path
-      else
-        # point d'interrogation par defaut
-        picture = 'http://a398.idata.over-blog.com/60x60/3/91/14/12/novembre-2010/point-d-interrogation-bleu-ciel.jpg'
-      end
-
-      a = {
-        id:  slot.id,
-        start:  slot.start_at,
-        end: slot.end_at,
-        title: Role.find_by(id: slot.role_id).name, # nom du role
-        role_id: slot.role_id, # nom du role
-        created_at: slot.created_at,
-        updated_at: slot.updated_at,
-        color: Role.find_by(id: slot.role_id).role_color,
-        planning_id: slot.planning_id,
-        user_id: User.find(slot.user_id).id,
-        picture: picture
-      }
-
-      picture_solution = 'http://res.cloudinary.com/dksqsr3pd/image/upload/c_fill,r_60,w_60/' + User.find_by(first_name: 'jean').profile_picture.path
-      user_id_solution = User.find_by(first_name: 'jean').id
-
-      b = {
-        id: slot.id,
-        start: slot.start_at,
-        end: slot.end_at,
-        title: Role.find_by(id: slot.role_id).name, # nom du role
-        role_id: slot.role_id, # nom du role
-        created_at: slot.created_at,
-        updated_at: slot.updated_at,
-        color: Role.find_by(id: slot.role_id).role_color,
-        planning_id: slot.planning_id,
-        user_id: user_id_solution,
-        picture: picture_solution
-      }
-      @slots_array << a
-      @slots_solution << if slot.user_id == User.find_by(first_name: 'no solution').id
-                           b
-                         else
-                           a
-                         end
-    end
   end
 
   # rubocop:enable MethodLength

--- a/app/controllers/plannings_controller.rb
+++ b/app/controllers/plannings_controller.rb
@@ -1,6 +1,6 @@
 # rubocop:disable Metrics/ClassLength
 class PlanningsController < ApplicationController
-  before_action :set_planning, only: [:skeleton, :users, :conflicts, :events]
+  before_action :set_planning, only: [:skeleton, :users, :conflicts, :events, :resultevents]
 
   # rubocop:disable AbcSize
 
@@ -48,61 +48,56 @@ class PlanningsController < ApplicationController
     @user_solution = User.find_by(first_name: 'jean')
     demo_method(@planning) if @planning.week_number == 37
 
-    # TODO_1: change this so that user_id is inherited from solution's effectivity
-    # TODO_2: change this so that solution_instance is determined according to Solution status
-    #  affecter aux slots le user de la solution de ce planning au statut :validated
-    # identifier la solution validée
-    #  affecter aux slots le user de la solution de ce planning au statut :validated
-      # identifier la solution validée
-      solution_instance = @planning.solutions.chosen.last
-      @slots.each do |slot|
-        solution_slot = solution_instance.solution_slots.select{|x| x.slot == slot }
-        # Fake solution > def user id solution
-        if !User.find(solution_slot.user_id).profile_picture.nil?
-          # picture du user
-          picture = 'http://res.cloudinary.com/dksqsr3pd/image/upload/c_fill,r_60,w_60/' + User.find(solution_slot.user_id).profile_picture.path
-        else
-          # point d'interrogation par defaut
-          picture = 'http://a398.idata.over-blog.com/60x60/3/91/14/12/novembre-2010/point-d-interrogation-bleu-ciel.jpg'
-        end
-
-        a = {
-          id:  slot.id,
-          start:  slot.start_at,
-          end: slot.end_at,
-          title: Role.find_by(id: slot.role_id).name, # nom du role
-          role_id: slot.role_id, # nom du role
-          created_at: slot.created_at,
-          updated_at: slot.updated_at,
-          color: Role.find_by(id: slot.role_id).role_color,
-          planning_id: slot.planning_id,
-          user_id: User.find(solution_slot.user_id).id,
-          picture: picture
-        }
-
-        picture_solution = 'http://res.cloudinary.com/dksqsr3pd/image/upload/c_fill,r_60,w_60/' + User.find_by(first_name: 'jean').profile_picture.path
-        user_id_solution = User.find_by(first_name: 'jean').id
-
-        b = {
-          id: slot.id,
-          start: slot.start_at,
-          end: slot.end_at,
-          title: Role.find_by(id: slot.role_id).name, # nom du role
-          role_id: slot.role_id, # nom du role
-          created_at: slot.created_at,
-          updated_at: slot.updated_at,
-          color: Role.find_by(id: slot.role_id).role_color,
-          planning_id: slot.planning_id,
-          user_id: user_id_solution,
-          picture: picture_solution
-        }
-        @slots_array << a
-        @slots_solution << if solution_slot.user_id == User.find_by(first_name: 'no solution').id
-                             b
-                           else
-                             a
-                           end
+    @solution_instance = @planning.solutions.chosen.last
+    @solution_slots = @solution_instance.solution_slots # Array of SolutionSlots
+    @slots.each do |slot|
+      solution_slot = @solution_slots.select{ |x| x.slot == slot }.first
+      # Fake solution > def user id solution
+      if !User.find(solution_slot.user.id).profile_picture.nil?
+        # picture du user
+        picture = 'http://res.cloudinary.com/dksqsr3pd/image/upload/c_fill,r_60,w_60/' + User.find(solution_slot.user.id).profile_picture.path
+      else
+        # point d'interrogation par defaut
+        picture = 'http://a398.idata.over-blog.com/60x60/3/91/14/12/novembre-2010/point-d-interrogation-bleu-ciel.jpg'
       end
+
+      a = {
+        id:  slot.id,
+        start:  slot.start_at,
+        end: slot.end_at,
+        title: Role.find_by(id: slot.role_id).name, # nom du role
+        role_id: slot.role_id, # nom du role
+        created_at: slot.created_at,
+        updated_at: slot.updated_at,
+        color: Role.find_by(id: slot.role_id).role_color,
+        planning_id: slot.planning_id,
+        user_id: User.find(solution_slot.user).id,
+        picture: picture
+      }
+
+      picture_solution = 'http://res.cloudinary.com/dksqsr3pd/image/upload/c_fill,r_60,w_60/' + User.find_by(first_name: 'jean').profile_picture.path
+      user_id_solution = User.find_by(first_name: 'jean').id
+
+      b = {
+        id: slot.id,
+        start: slot.start_at,
+        end: slot.end_at,
+        title: Role.find_by(id: slot.role_id).name, # nom du role
+        role_id: slot.role_id, # nom du role
+        created_at: slot.created_at,
+        updated_at: slot.updated_at,
+        color: Role.find_by(id: slot.role_id).role_color,
+        planning_id: slot.planning_id,
+        user_id: user_id_solution,
+        picture: picture_solution
+      }
+      @slots_array << a
+      @slots_solution << if solution_slot.user == User.find_by(first_name: 'no solution')
+                           b
+                         else
+                           a
+                         end
+    end
   end
 
   # rubocop:enable MethodLength
@@ -135,6 +130,10 @@ class PlanningsController < ApplicationController
     # render events.json.jbuilder
   end
 
+  def resultevents
+    # renders resultevents.json.jbuilder
+  end
+
   private
 
   def plannings_list
@@ -161,22 +160,26 @@ class PlanningsController < ApplicationController
     vendeur = Role.find_by(name: 'vendeur')
     barista = Role.find_by(name: 'barista')
     # useless
-    s1 = planning.slots.where(user_id: nil).where(role_id: vendeur.id)[0]
+    # sélectionner le slots pour lesquels user_id = nil + role_id = vendeur.id
+    s1 = planning.slots.select{|x| x.get_associated_chosen_solution_slot.user == nil && x.role_id == vendeur.id }.first
+    # remplacer le user de ce slot par 'valentine'
     if !s1.nil? && s1.user.nil?
-      s1.user = User.find_by(first_name: 'valentine')
-      s1.save
+      s1.get_associated_chosen_solution_slot.user = User.find_by(first_name: 'valentine')
+      s1.get_associated_chosen_solution_slot.save
     end
 
-    s2 = planning.slots.where(user_id: nil).where(role_id: barista.id)[0]
+    # sélectionner le slots pour lesquels user_id = nil + role_id = barista.id
+    s2 = planning.slots.select{|x| x.get_associated_chosen_solution_slot.user == nil && x.role_id == barista.id }.first
     if !s2.nil? && s2.user.nil?
-      s2.user = User.find_by(first_name: 'paul')
-      s2.save
+      s2.get_associated_chosen_solution_slot.user = User.find_by(first_name: 'paul')
+      s2.get_associated_chosen_solution_slot.save
     end
-    # added
-    s = Slot.where(user_id: User.find_by(first_name: 'axel').id)
+
+    # get slots where user_id == axel
+    s = Slot.select{|x| x.get_associated_chosen_solution_slot.user == User.find_by(first_name: 'axel') }
     s.each do |slot|
-      slot.user_id = User.find_by(first_name: 'arielle').id
-      slot.save!
+      slot.get_associated_chosen_solution_slot.user = User.find_by(first_name: 'arielle')
+      slot.get_associated_chosen_solution_slot.save!
     end
   end
   # rubocop:enable AbcSize, MethodLength

--- a/app/controllers/plannings_controller.rb
+++ b/app/controllers/plannings_controller.rb
@@ -48,55 +48,10 @@ class PlanningsController < ApplicationController
     @user_solution = User.find_by(first_name: 'jean')
     demo_method(@planning) if @planning.week_number == 37
 
-    @solution_instance = @planning.solutions.chosen.last
-    @solution_slots = @solution_instance.solution_slots # Array of SolutionSlots
-    @slots.each do |slot|
-      solution_slot = @solution_slots.select{ |x| x.slot == slot }.first
-      # Fake solution > def user id solution
-      if !User.find(solution_slot.user.id).profile_picture.nil?
-        # picture du user
-        picture = 'http://res.cloudinary.com/dksqsr3pd/image/upload/c_fill,r_60,w_60/' + User.find(solution_slot.user.id).profile_picture.path
-      else
-        # point d'interrogation par defaut
-        picture = 'http://a398.idata.over-blog.com/60x60/3/91/14/12/novembre-2010/point-d-interrogation-bleu-ciel.jpg'
-      end
-
-      a = {
-        id:  slot.id,
-        start:  slot.start_at,
-        end: slot.end_at,
-        title: Role.find_by(id: slot.role_id).name, # nom du role
-        role_id: slot.role_id, # nom du role
-        created_at: slot.created_at,
-        updated_at: slot.updated_at,
-        color: Role.find_by(id: slot.role_id).role_color,
-        planning_id: slot.planning_id,
-        user_id: User.find(solution_slot.user).id,
-        picture: picture
-      }
-
-      picture_solution = 'http://res.cloudinary.com/dksqsr3pd/image/upload/c_fill,r_60,w_60/' + User.find_by(first_name: 'jean').profile_picture.path
-      user_id_solution = User.find_by(first_name: 'jean').id
-
-      b = {
-        id: slot.id,
-        start: slot.start_at,
-        end: slot.end_at,
-        title: Role.find_by(id: slot.role_id).name, # nom du role
-        role_id: slot.role_id, # nom du role
-        created_at: slot.created_at,
-        updated_at: slot.updated_at,
-        color: Role.find_by(id: slot.role_id).role_color,
-        planning_id: slot.planning_id,
-        user_id: user_id_solution,
-        picture: picture_solution
-      }
-      @slots_array << a
-      @slots_solution << if solution_slot.user == User.find_by(first_name: 'no solution')
-                           b
-                         else
-                           a
-                         end
+    if !@planning.solutions.exists?
+      flash.now[:alert] = "Générez des solutions pour votre planning"
+    elsif !@planning.solutions.chosen.exists?
+      flash.now[:alert] = "Validez une solution pour votre planning"
     end
   end
 

--- a/app/controllers/slots_controller.rb
+++ b/app/controllers/slots_controller.rb
@@ -6,7 +6,7 @@ class SlotsController < ApplicationController
   def create
     slot_model = Slot.new(slot_params)
     user_id = User.find_by(first_name: 'no solution').id
-    slot_model.user_id = user_id
+    # slot_model.user_id = user_id
     slot_list = [slot_model]
 
     clicked_day = slot_params[:start_at].to_datetime.strftime("%u").to_i

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -48,15 +48,15 @@ class Slot < ApplicationRecord
                planning_id, start_at, end_at, role_id)
   end
 
+  def get_chosen_solution_slot
+    # for a given slot, get the instance of solution_slot which is associated to it and
+    # belongs to the chosen solution
+    self.solution_slots.select{ |x| x.solution.chosen? && x.slot == self }.first
+  end
+
   private
 
   def set_planning_status
     planning&.set_status
-  end
-
-  def self.get_chosen_solution_slot
-    # for a given slot, get the instance of solution_slot which is associated to it and
-    # belongs to the chosen solution
-    SolutionSlot.select{ |x| x.solution.chosen? && x.slot == self }.first
   end
 end

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -27,7 +27,6 @@
 class Slot < ApplicationRecord
   belongs_to :planning, optional: true
   belongs_to :role
-  belongs_to :user, optional: true
   validates :role_id, presence: true
   after_save :set_planning_status
   has_many :solution_slots, dependent: :destroy

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -7,7 +7,6 @@
 #  end_at      :datetime
 #  planning_id :integer
 #  role_id     :integer
-#  user_id     :integer
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #
@@ -15,13 +14,11 @@
 #
 #  index_slots_on_planning_id  (planning_id)
 #  index_slots_on_role_id      (role_id)
-#  index_slots_on_user_id      (user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (planning_id => plannings.id)
 #  fk_rails_...  (role_id => roles.id)
-#  fk_rails_...  (user_id => users.id)
 #
 
 class Slot < ApplicationRecord

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -54,7 +54,7 @@ class Slot < ApplicationRecord
     planning&.set_status
   end
 
-  def self.get_associated_chosen_solution_slot
+  def self.get_chosen_solution_slot
     # for a given slot, get the instance of solution_slot which is associated to it and
     # belongs to the chosen solution
     SolutionSlot.select{ |x| x.solution.chosen? && x.slot == self }.first

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -27,6 +27,7 @@ class Slot < ApplicationRecord
   validates :role_id, presence: true
   after_save :set_planning_status
   has_many :solution_slots, dependent: :destroy
+  has_many :solutions, through: :solution_slots
 
   def self.slot_templates
     slot_templates = []
@@ -51,5 +52,11 @@ class Slot < ApplicationRecord
 
   def set_planning_status
     planning&.set_status
+  end
+
+  def self.get_associated_chosen_solution_slot
+    # for a given slot, get the instance of solution_slot which is associated to it and
+    # belongs to the chosen solution
+    SolutionSlot.select{ |x| x.solution.chosen? && x.slot == self }.first
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,6 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
   has_many :constraints, dependent: :destroy
   has_many :plannings, through: :teams
-  has_many :slots, dependent: :destroy
   has_many :roles, through: :role_users
   has_many :role_users, dependent: :destroy
   has_many :teams, dependent: :destroy

--- a/app/views/plannings/_resultevent.json.jbuilder
+++ b/app/views/plannings/_resultevent.json.jbuilder
@@ -1,10 +1,11 @@
 # rubocop:disable LineLength
+binding.pry
 json.extract! slot, :id, :role_id, :created_at, :updated_at, :planning_id
 json.start slot.start_at
 json.end slot.end_at
 json.title slot.role.name
 json.color slot.role.role_color
 json.nombre planning_count_people_on_similar_slot(planning, slot)
-# json.user_id  solution_slot.user_id
-# json.picture  'http://res.cloudinary.com/dksqsr3pd/image/upload/c_fill,r_60,w_60/' + User.find(solution_slot.user_id).profile_picture.path
+json.user_id  solution_slot.user.id
+json.picture  'http://res.cloudinary.com/dksqsr3pd/image/upload/c_fill,r_60,w_60/' + User.find(solution_slot.user_id).profile_picture.path
 # rubocop:enable LineLength

--- a/app/views/plannings/_resultevent.json.jbuilder
+++ b/app/views/plannings/_resultevent.json.jbuilder
@@ -1,5 +1,4 @@
 # rubocop:disable LineLength
-binding.pry
 json.extract! slot, :id, :role_id, :created_at, :updated_at, :planning_id
 json.start slot.start_at
 json.end slot.end_at

--- a/app/views/plannings/_resultevent.json.jbuilder
+++ b/app/views/plannings/_resultevent.json.jbuilder
@@ -5,6 +5,6 @@ json.end slot.end_at
 json.title slot.role.name
 json.color slot.role.role_color
 json.nombre planning_count_people_on_similar_slot(planning, slot)
-json.user_id  solution_slot.user.id
-json.picture  'http://res.cloudinary.com/dksqsr3pd/image/upload/c_fill,r_60,w_60/' + User.find(solution_slot.user_id).profile_picture.path
+json.user_id  solution_slot_user_id
+json.picture  'http://res.cloudinary.com/dksqsr3pd/image/upload/c_fill,r_60,w_60/' + User.find(solution_slot_user_id).profile_picture.path
 # rubocop:enable LineLength

--- a/app/views/plannings/conflicts.html.erb
+++ b/app/views/plannings/conflicts.html.erb
@@ -185,7 +185,7 @@
       hiddenDays: [ 0], // hider dimanche
       height: "auto", // implique pas de scroll à l'intérieur du calendrier
       aspectRatio: 4,
-      events: '<%= events_planning_path(@planning.id, format: :json) %>',
+      events: '<%= resultevents_planning_path(@planning.id, format: :json) %>',
 
       // simulation résolution conflit
       eventClick: function(calEvent, jsEvent, view) {

--- a/app/views/plannings/resultevents.json.jbuilder
+++ b/app/views/plannings/resultevents.json.jbuilder
@@ -1,4 +1,4 @@
 
 json.array! @planning.slots do |slot|
-  json.partial! 'plannings/resultevent', planning: @planning, slot: slot, solution_slot: SolutionSlot.select{ |x| x.solution.chosen? && x.slot == slot }.first
+  json.partial! 'plannings/resultevent', planning: @planning, slot: slot, solution_slot: slot.get_chosen_solution_slot
 end

--- a/app/views/plannings/resultevents.json.jbuilder
+++ b/app/views/plannings/resultevents.json.jbuilder
@@ -1,0 +1,4 @@
+
+json.array! @planning.slots do |slot|
+  json.partial! 'plannings/resultevent', planning: @planning, slot: slot, solution_slot: SolutionSlot.select{ |x| x.solution.chosen? && x.slot == slot }.first
+end

--- a/app/views/plannings/resultevents.json.jbuilder
+++ b/app/views/plannings/resultevents.json.jbuilder
@@ -1,4 +1,10 @@
-
-json.array! @planning.slots do |slot|
-  json.partial! 'plannings/resultevent', planning: @planning, slot: slot, solution_slot: slot.get_chosen_solution_slot
+if @planning.solutions.chosen.exists?
+  json.array! @planning.slots do |slot|
+    json.partial! 'plannings/resultevent', planning: @planning, slot: slot, solution_slot_user_id: slot.get_chosen_solution_slot.user.id
+  end
+else
+  json.array! @planning.slots do |slot|
+    json.partial! 'plannings/resultevent', planning: @planning, slot: slot, solution_slot_user_id: User.find_by(first_name: 'no solution')
+  end
 end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
     resources :compute_solutions, only: [:index, :create]
     member do
       get :events, format: :json
+      get :resultevents, format: :json
     end
   end
 

--- a/db/migrate/20180208133255_remove_user_id_to_slots.rb
+++ b/db/migrate/20180208133255_remove_user_id_to_slots.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdToSlots < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :slots, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180205161023) do
+ActiveRecord::Schema.define(version: 20180208133255) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,12 +92,10 @@ ActiveRecord::Schema.define(version: 20180205161023) do
     t.datetime "end_at"
     t.integer  "planning_id"
     t.integer  "role_id"
-    t.integer  "user_id"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
     t.index ["planning_id"], name: "index_slots_on_planning_id", using: :btree
     t.index ["role_id"], name: "index_slots_on_role_id", using: :btree
-    t.index ["user_id"], name: "index_slots_on_user_id", using: :btree
   end
 
   create_table "solution_slots", force: :cascade do |t|
@@ -159,7 +157,6 @@ ActiveRecord::Schema.define(version: 20180205161023) do
   add_foreign_key "role_users", "users"
   add_foreign_key "slots", "plannings"
   add_foreign_key "slots", "roles"
-  add_foreign_key "slots", "users"
   add_foreign_key "solution_slots", "slots"
   add_foreign_key "solution_slots", "solutions"
   add_foreign_key "solution_slots", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -460,7 +460,6 @@ Slot.create!(
   start_at: "2017-09-11 08:00",
   end_at: "2017-09-11 14:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("pierre").id
   )
 
 Slot.create!(
@@ -468,7 +467,6 @@ Slot.create!(
   start_at: "2017-09-11 08:00",
   end_at: "2017-09-11 14:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("jeannie").id
   )
 
 # 2
@@ -477,7 +475,6 @@ Slot.create!(
   start_at: "2017-09-11 14:00",
   end_at: "2017-09-11 20:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("jacques").id
   )
 
 Slot.create!(
@@ -485,7 +482,6 @@ Slot.create!(
   start_at: "2017-09-11 14:00",
   end_at: "2017-09-11 20:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("bob").id
   )
 # 3
 Slot.create!(
@@ -493,7 +489,6 @@ Slot.create!(
   start_at: "2017-09-11 10:00",
   end_at: "2017-09-11 14:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("axel").id
   )
 
 Slot.create!(
@@ -501,7 +496,6 @@ Slot.create!(
   start_at: "2017-09-11 10:00",
   end_at: "2017-09-11 13:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("valentine").id
   )
 
 Slot.create!(
@@ -509,7 +503,6 @@ Slot.create!(
   start_at: "2017-09-11 10:00",
   end_at: "2017-09-11 13:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("emma").id
   )
 
 #4
@@ -518,7 +511,6 @@ Slot.create!(
   start_at: "2017-09-11 15:00",
   end_at: "2017-09-11 18:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("axel").id
   )
 
 Slot.create!(
@@ -526,7 +518,6 @@ Slot.create!(
   start_at: "2017-09-11 14:00",
   end_at: "2017-09-11 18:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("valentine").id
   )
 
 Slot.create!(
@@ -534,7 +525,6 @@ Slot.create!(
   start_at: "2017-09-11 14:00",
   end_at: "2017-09-11 18:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("emma").id
   )
 
 #5
@@ -543,7 +533,6 @@ Slot.create!(
   start_at: "2017-09-11 08:00",
   end_at: "2017-09-11 15:30",
   role_id: Role.find_by_name("barista").id,
-  user_id: User.find_by_first_name("paul").id
   )
 
 ##############12/09
@@ -553,7 +542,6 @@ Slot.create!(
   start_at: "2017-09-12 08:00",
   end_at: "2017-09-12 14:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("pierre").id
   )
 
 Slot.create!(
@@ -561,7 +549,6 @@ Slot.create!(
   start_at: "2017-09-12 08:00",
   end_at: "2017-09-12 14:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("jeannie").id
   )
 
 #7
@@ -570,14 +557,12 @@ Slot.create!(
   start_at: "2017-09-12 14:00",
   end_at: "2017-09-12 20:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("jacques").id
   )
 Slot.create!(
   planning_id: p.id,
   start_at: "2017-09-12 14:00",
   end_at: "2017-09-12 20:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("bob").id
   )
 
 #8
@@ -586,14 +571,12 @@ Slot.create!(
   start_at: "2017-09-12 10:00",
   end_at: "2017-09-12 13:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("axel").id
   )
 Slot.create!(
   planning_id: p.id,
   start_at: "2017-09-12 10:00",
   end_at: "2017-09-12 14:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("valentine").id
   )
 #9
 Slot.create!(
@@ -601,14 +584,12 @@ Slot.create!(
   start_at: "2017-09-12 14:00",
   end_at: "2017-09-12 18:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("axel").id
   )
 Slot.create!(
   planning_id: p.id,
   start_at: "2017-09-12 15:00",
   end_at: "2017-09-12 18:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("valentine").id
   )
 
 #10
@@ -617,7 +598,6 @@ Slot.create!(
   start_at: "2017-09-12 8:00",
   end_at: "2017-09-12 15:30",
   role_id: Role.find_by_name("barista").id,
-  user_id: User.find_by_first_name("paul").id
   )
 #### 13/09
 
@@ -626,7 +606,6 @@ Slot.create!(
   start_at: "2017-09-13 08:00",
   end_at: "2017-09-13 14:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("pierre").id
   )
 
 Slot.create!(
@@ -634,7 +613,6 @@ Slot.create!(
   start_at: "2017-09-13 08:00",
   end_at: "2017-09-13 14:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("jeannie").id
   )
 
 #12
@@ -643,36 +621,13 @@ Slot.create!(
   start_at: "2017-09-13 14:00",
   end_at: "2017-09-13 20:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("jacques").id
   )
 Slot.create!(
   planning_id: p.id,
   start_at: "2017-09-13 14:00",
   end_at: "2017-09-13 20:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("bob").id
   )
-
-
-# TO BE CRETED DURING DEMO
-# Slot.create!(
-#   planning_id: p.id,
-#   start_at: "2017-09-13 10:00",
-#   end_at: "2017-09-13 18:00",
-#   role_id: Role.find_by_name("vendeur").id,
-#   user_id: User.find_by_first_name("valentine").id
-#   )
-
-# #15
-# Slot.create!(
-#   planning_id: p.id,
-#   start_at: "2017-09-13 10:00",
-#   end_at: "2017-09-13 15:30",
-#   role_id: Role.find_by_name("barista").id,
-#   user_id: User.find_by_first_name("paul").id
-#   )
-
-#######14/09
 
 #16
 Slot.create!(
@@ -680,14 +635,12 @@ Slot.create!(
   start_at: "2017-09-14 08:00",
   end_at: "2017-09-14 14:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("pierre").id
   )
 Slot.create!(
   planning_id: p.id,
   start_at: "2017-09-14 08:00",
   end_at: "2017-09-14 14:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("jeannie").id
   )
 
 #
@@ -696,14 +649,12 @@ Slot.create!(
   start_at: "2017-09-14 14:00",
   end_at: "2017-09-14 20:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("jacques").id
   )
 Slot.create!(
   planning_id: p.id,
   start_at: "2017-09-14 14:00",
   end_at: "2017-09-14 20:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("bob").id
   )
 
 #18
@@ -712,7 +663,6 @@ Slot.create!(
   start_at: "2017-09-14 10:00",
   end_at: "2017-09-14 13:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("axel").id
   )
 
 #19
@@ -721,21 +671,18 @@ Slot.create!(
   start_at: "2017-09-14 10:00",
   end_at: "2017-09-14 14:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("emma").id
   )
 Slot.create!(
   planning_id: p.id,
   start_at: "2017-09-14 14:00",
   end_at: "2017-09-14 18:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("axel").id
   )
 Slot.create!(
   planning_id: p.id,
   start_at: "2017-09-14 15:00",
   end_at: "2017-09-14 18:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("emma").id
   )
 #20
 Slot.create!(
@@ -743,7 +690,6 @@ Slot.create!(
   start_at: "2017-09-14 08:00",
   end_at: "2017-09-14 15:30",
   role_id: Role.find_by_name("barista").id,
-  user_id: User.find_by_first_name("paul").id
   )
 
 #### 15/09
@@ -753,14 +699,12 @@ Slot.create!(
   start_at: "2017-09-15 08:00",
   end_at: "2017-09-15 14:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("pierre").id
   )
 Slot.create!(
   planning_id: p.id,
   start_at: "2017-09-15 08:00",
   end_at: "2017-09-15 14:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("jeannie").id
   )
 #22
 Slot.create!(
@@ -768,14 +712,12 @@ Slot.create!(
   start_at: "2017-09-15 14:00",
   end_at: "2017-09-15 20:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("jacques").id
   )
 Slot.create!(
   planning_id: p.id,
   start_at: "2017-09-15 14:00",
   end_at: "2017-09-15 20:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("bob").id
   )
 #23
 Slot.create!(
@@ -783,14 +725,12 @@ Slot.create!(
   start_at: "2017-09-15 10:00",
   end_at: "2017-09-15 14:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("axel").id
   )
 Slot.create!(
   planning_id: p.id,
   start_at: "2017-09-15 10:00",
   end_at: "2017-09-15 13:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("emma").id
   )
 #24
 Slot.create!(
@@ -798,14 +738,12 @@ Slot.create!(
   start_at: "2017-09-15 15:00",
   end_at: "2017-09-15 18:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("axel").id
   )
 Slot.create!(
   planning_id: p.id,
   start_at: "2017-09-15 14:00",
   end_at: "2017-09-15 18:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("emma").id
   )
 
 Slot.create!(
@@ -813,7 +751,6 @@ Slot.create!(
   start_at: "2017-09-15 8:00",
   end_at: "2017-09-15 15:30",
   role_id: Role.find_by_name("barista").id,
-  user_id: User.find_by_first_name("paul").id
   )
 
 #### 16/09 Samedi Grosse journée
@@ -823,14 +760,12 @@ Slot.create!(
   start_at: "2017-09-16 08:00",
   end_at: "2017-09-16 14:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("pierre").id
   )
 Slot.create!(
   planning_id: p.id,
   start_at: "2017-09-16 08:00",
   end_at: "2017-09-16 14:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("jeannie").id
   )
 #27
 Slot.create!(
@@ -838,14 +773,12 @@ Slot.create!(
   start_at: "2017-09-16 14:00",
   end_at: "2017-09-16 20:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("jacques").id
   )
 Slot.create!(
   planning_id: p.id,
   start_at: "2017-09-16 14:00",
   end_at: "2017-09-16 20:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("bob").id
   )
 #28
 Slot.create!(
@@ -853,21 +786,18 @@ Slot.create!(
   start_at: "2017-09-16 10:00",
   end_at: "2017-09-16 13:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("axel").id
   )
 Slot.create!(
   planning_id: p.id,
   start_at: "2017-09-16 10:00",
   end_at: "2017-09-16 13:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("valentine").id
   )
 Slot.create!(
   planning_id: p.id,
   start_at: "2017-09-16 10:00",
   end_at: "2017-09-16 14:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("emma").id
   )
 #29
 Slot.create!(
@@ -875,14 +805,12 @@ Slot.create!(
   start_at: "2017-09-16 14:00",
   end_at: "2017-09-16 18:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("axel").id
   )
 Slot.create!(
   planning_id: p.id,
   start_at: "2017-09-16 14:00",
   end_at: "2017-09-16 18:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("valentine").id
   )
 
 Slot.create!(
@@ -890,7 +818,6 @@ Slot.create!(
   start_at: "2017-09-16 15:00",
   end_at: "2017-09-16 18:00",
   role_id: Role.find_by_name("vendeur").id,
-  user_id: User.find_by_first_name("emma").id
   )
 
 
@@ -901,7 +828,6 @@ Slot.create!(
   start_at: "2017-09-16 8:00",
   end_at: "2017-09-16 15:30",
   role_id: Role.find_by_name("barista").id,
-  user_id: User.find_by_first_name("no solution").id
   )
 
 Slot.create!(
@@ -909,7 +835,6 @@ Slot.create!(
   start_at: "2017-08-28 07:00",
   end_at: "2017-08-28 15:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("magalie").id
   )
 
 Slot.create!(
@@ -917,7 +842,6 @@ Slot.create!(
   start_at: "2017-09-4 07:00",
   end_at: "2017-09-4 15:00",
   role_id: Role.find_by_name("mécano").id,
-  user_id: User.find_by_first_name("magalie").id
   )
 
 
@@ -933,7 +857,6 @@ Slot.create!(
   start_at: "2017-08-29 07:00",
   end_at: "2017-08-29 15:00",
   role_id: Role.find_by_name("barista").id,
-  user_id: User.find_by_first_name("no solution").id
   )
 
 Slot.create!(
@@ -941,7 +864,6 @@ Slot.create!(
   start_at: "2017-08-29 07:00",
   end_at: "2017-08-29 15:00",
   role_id: Role.find_by_name("barista").id,
-  user_id: User.find_by_first_name("no solution").id
   )
 
 puts ""

--- a/test/fixtures/slots.yml
+++ b/test/fixtures/slots.yml
@@ -7,7 +7,6 @@
 #  end_at      :datetime
 #  planning_id :integer
 #  role_id     :integer
-#  user_id     :integer
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #
@@ -15,13 +14,11 @@
 #
 #  index_slots_on_planning_id  (planning_id)
 #  index_slots_on_role_id      (role_id)
-#  index_slots_on_user_id      (user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (planning_id => plannings.id)
 #  fk_rails_...  (role_id => roles.id)
-#  fk_rails_...  (user_id => users.id)
 #
 
 two_hours:

--- a/test/models/slot_test.rb
+++ b/test/models/slot_test.rb
@@ -7,7 +7,6 @@
 #  end_at      :datetime
 #  planning_id :integer
 #  role_id     :integer
-#  user_id     :integer
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #
@@ -15,13 +14,11 @@
 #
 #  index_slots_on_planning_id  (planning_id)
 #  index_slots_on_role_id      (role_id)
-#  index_slots_on_user_id      (user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (planning_id => plannings.id)
 #  fk_rails_...  (role_id => roles.id)
-#  fk_rails_...  (user_id => users.id)
 #
 
 require 'test_helper'


### PR DESCRIPTION
**Raccrocher le user d'un slot dans le modèle Slot et non plus dans le modèle SolutionSlot.**

**1) migration** pour enlever la column user_id de slots.
le user_id d'un slot devient => `solution_slot.get_chosen_solution_slot.user`
où `get_chosen_solution_slot` est une méthode de la class Slot.

**2) modification de la génération des json** alimentant les calendars dans `PlanningController`

a - dans **/skeleton**, on ne display pas le user_id. 
Le calendar fait appel à : `events: '<%= events_planning_path(@planning.id, format: :json) %>'` qui nous dirige vers events.json.jbuilder.
Ce json builder ne construit pas de propriétés liées au user (user_id et picture).

b - dans **/conflicts,** on display le user_id
Le calendar fait appel à  `events: '<%= resultevents_planning_path(@planning.id, format: :json) %>`
On génère un json avec :
_s'il existe une solution chosen => user = celui du solution_slot "gagnant"
_ s'il existe des solutions mais pas de solution chosen => user = 'no solution' + on display un flash_notice "choisissez une solution parmi vos solutions"
_ si pas de solutions => user = 'no solution' + on display flash notice "pas encore de solution générée pour ce planning"