### PR TITLE
added some CSS

### DIFF
--- a/app/assets/stylesheets/components/_calendar.scss
+++ b/app/assets/stylesheets/components/_calendar.scss
@@ -1,6 +1,17 @@
 #calendar {
   /*override le theme par defaut*/
   /*noms des jours*/
+
+  // ligne au-dessus des heures pleines
+  .fc-minor{
+    border-bottom: dotted $mysuperlightgrey 3px;
+  }
+
+  // ligne au dessous des heures pleines
+  .fc-widget-content{
+    border-top: dotted white 0px;
+  }
+
   .fc-day-header {
     color: $mygrey;
     font-family: "Oswald";


### PR DESCRIPTION
ajout de CSS pour que les lignes du calendar correspondent à des heures pleines

![screenshot from 2018-05-15 18-53-08](https://user-images.githubusercontent.com/29304869/40071674-c11cf47e-5871-11e8-92b8-1d645ab67347.png)
