### PR TITLE
update solution relevance + planning status on solution_slot update

### DIFF
--- a/app/models/solution_slot.rb
+++ b/app/models/solution_slot.rb
@@ -67,6 +67,9 @@ class SolutionSlot < ApplicationRecord
     self.solution.total_over_time
     self.solution.evaluate_nb_conflicts
     self.solution.evaluate_nb_overlaps
+    self.solution.evaluate_relevance
+    # update planning status (maybe you resolved all conflicts)
+    self.planning.set_status
     # update solution_slot (no attributes to update for now)
     # update compute_solution (nb_optimal_solutions)
     self.solution.compute_solution.evaluate_nb_optimal_solutions


### PR DESCRIPTION
**On met à jour le statut du planning lorsque l'on update 1 solution_slot.**
(car potentiellement on aura résolu les conflicts)

--> nécessite aussi de màj la relevance de la solution (c'est un critère qui sert à `set_status` d'un planning)