### PR TITLE
115 solution ranking

### DIFF
--- a/app/models/compute_solution.rb
+++ b/app/models/compute_solution.rb
@@ -2,23 +2,28 @@
 #
 # Table name: compute_solutions
 #
-#  id                      :integer          not null, primary key
-#  status                  :integer
-#  planning_id             :integer
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  nb_solutions            :integer
-#  nb_optimal_solutions    :integer
-#  nb_iterations           :integer
-#  nb_possibilities_theory :integer
-#  calculation_length      :decimal(, )
-#  nb_cuts_within_tree     :integer
-#  p_nb_slots              :integer
-#  p_nb_hours              :string
-#  p_nb_hours_roles        :text
-#  team                    :text
-#  p_list_of_slots_ids     :text
-#  timestamps_algo         :text
+#  id                                      :integer          not null, primary key
+#  status                                  :integer
+#  planning_id                             :integer
+#  created_at                              :datetime         not null
+#  updated_at                              :datetime         not null
+#  nb_solutions                            :integer
+#  nb_optimal_solutions                    :integer
+#  nb_iterations                           :integer
+#  nb_possibilities_theory                 :integer
+#  calculation_length                      :decimal(, )
+#  nb_cuts_within_tree                     :integer
+#  p_nb_slots                              :integer
+#  p_nb_hours                              :string
+#  p_nb_hours_roles                        :text
+#  team                                    :text
+#  p_list_of_slots_ids                     :text
+#  timestamps_algo                         :text
+#  go_through_solutions_mean_time_per_slot :float
+#  solution_storing_mean_time_per_slot     :float
+#  mean_time_per_slot                      :float
+#  fail_level                              :text
+#  percent_tree_covered                    :float
 #
 # Indexes
 #

--- a/app/models/compute_solution.rb
+++ b/app/models/compute_solution.rb
@@ -17,6 +17,7 @@
 #  p_nb_hours              :string
 #  p_nb_hours_roles        :text
 #  team                    :text
+#  p_list_of_slots_ids     :text
 #
 # Indexes
 #

--- a/app/models/constraint.rb
+++ b/app/models/constraint.rb
@@ -30,4 +30,9 @@ class Constraint < ApplicationRecord
 
   enum status: [:submitted, :validated, :refused]
   enum category: [:conge_annuel, :maladie, :preference]
+
+  def length
+    # duration in seconds
+    end_at - start_at
+  end
 end

--- a/app/models/planning.rb
+++ b/app/models/planning.rb
@@ -30,6 +30,10 @@ class Planning < ApplicationRecord
     solutions.find_by(effectivity: :chosen)
   end
 
+  def has_a_chosen_solution?
+    solutions.select{ |s| s.effectivity == :chosen }.count.positive?
+  end
+
   def chosen_solution_slots
     chosen_solution.solution_slots
   end
@@ -57,4 +61,60 @@ class Planning < ApplicationRecord
       in_progress!
     end
   end
+
+  def get_previous_week_planning
+    # => id du planning de la semaine précédente
+    if week_number == 1
+      Planning.find_by(year: year - 1, week_number: get_latest_week_number_of_a_year(year - 1))
+    else
+      Planning.find_by(year: year, week_number: week_number)
+    end
+  end
+
+  def get_next_week_planning
+    # => id du planning de la semaine suivante
+    if week_number == get_latest_week_number_of_a_year(year)
+      Planning.find_by(year: year + 1, week_number: 1)
+    else
+      Planning.find_by(year: year, week_number: week_number + 1)
+    end
+  end
+
+  def evaluate_timeframe_to_test_nb_users_six_consec_days_fail
+    if get_previous_week_planning.has_a_chosen_solution?
+      if get_next_week_planning.has_a_chosen_solution?
+        start_time = get_first_date_of_a_week(get_previous_week_planning.year,
+          get_previous_week_planning.week_number)
+        end_time = get_last_date_of_a_week(get_next_week_planning.year,
+          get_next_week_planning.week_number)
+      else
+        start_time = get_first_date_of_a_week(get_previous_week_planning.year,
+          get_previous_week_planning.week_number)
+        end_time = get_last_date_of_a_week(planning.year, planning.week_number)
+      end
+    elsif get_next_week_planning.has_a_chosen_solution?
+      start_time = get_first_date_of_a_week(year, week_number)
+      end_time = get_last_date_of_a_week(get_next_week_planning.year,
+          get_next_week_planning.week_number)
+    else
+      start_time = get_first_date_of_a_week(year, week_number)
+      end_time = get_last_date_of_a_week(year, week_number)
+    end
+    return [start_time .. end_time]
+  end
+
+  private
+
+  def get_latest_week_number_of_a_year(year)
+    Planning.where('year = ?', year).map(&:week_number).max
+  end
+
+  def get_first_date_of_a_week(year, week_number)
+    Date.commercial(year, week_number, 1).beginning_of_week
+  end
+
+  def get_last_date_of_a_week(year, week_number)
+    Date.commercial(year, week_number, 1).end_of_week
+  end
+
 end

--- a/app/models/planning.rb
+++ b/app/models/planning.rb
@@ -52,12 +52,57 @@ class Planning < ApplicationRecord
       c.created_at < self.slots.map(&:updated_at).max }.sort
   end
 
+  def number_of_days
+    # integer : nb of days where there is at least 1 slot
+    nb_days = 0
+    timeframe.first.each do |date|
+      nb_days += 1 if slots_on_that_day?(date)
+    end
+    nb_days
+  end
+
+  def list_of_days
+    # list of the days of a planning where >0 slots
+    list = []
+    timeframe.first.each do |date|
+      list << date if slots_on_that_day?(date)
+    end
+    list
+  end
+
+  def slots_on_that_day?(date)
+    # true if >0 slot on that day
+    slots.where('start_at <= ? and end_at >= ?',
+      DateTime.new(date.year, date.month, date.day, 24),
+      DateTime.new(date.year, date.month, date.day, 0) ).count.positive?
+  end
+
   def start_date
     Date.commercial(year, week_number, 1).beginning_of_week
   end
 
   def end_date
     Date.commercial(year, week_number, 1).end_of_week
+  end
+
+  def slots_availability_of_users
+    # hours (float) where users are available and skilled and there are some slots
+    # pour chaque slot, qui est dispo et skilled? (n)
+    # n * length of slot (hours)
+  end
+
+  def total_availability_of_users
+    # hours (float) where users are available within opening hours
+    r = 0
+    users.each do |user|
+      r += user.availability_in_hours(self)
+    end
+    r
+  end
+
+  def slots_total_duration
+    # sum of duration of all slots of the planning (hours, decimal)
+    slots.map(&:length).inject(:+)/3600
   end
 
   def hours_per_role
@@ -81,28 +126,8 @@ class Planning < ApplicationRecord
     end
   end
 
-  private
-
-  def seconds_in_hours(seconds)
-    [seconds / 3600, seconds / 60 % 60].map { |t| t.to_s.rjust(2,'0') }.join('h')
-  end
-
-  def get_previous_week_planning
-    # => id du planning de la semaine précédente
-    if week_number == 1
-      Planning.find_by(year: year - 1, week_number: get_latest_week_number_of_a_year(year - 1))
-    else
-      Planning.find_by(year: year, week_number: week_number)
-    end
-  end
-
-  def get_next_week_planning
-    # => id du planning de la semaine suivante
-    if week_number == get_latest_week_number_of_a_year(year)
-      Planning.find_by(year: year + 1, week_number: 1)
-    else
-      Planning.find_by(year: year, week_number: week_number + 1)
-    end
+  def timeframe
+    [get_first_date_of_a_week(year, week_number) .. get_last_date_of_a_week(year, week_number)]
   end
 
   def evaluate_timeframe_to_test_nb_users_six_consec_days_fail
@@ -129,8 +154,28 @@ class Planning < ApplicationRecord
     return [start_time .. end_time]
   end
 
-  def timeframe
-    [get_first_date_of_a_week(year, week_number) .. get_last_date_of_a_week(year, week_number)]
+  private
+
+  def seconds_in_hours(seconds)
+    [seconds / 3600, seconds / 60 % 60].map { |t| t.to_s.rjust(2,'0') }.join('h')
+  end
+
+  def get_previous_week_planning
+    # => id du planning de la semaine précédente
+    if week_number == 1
+      Planning.find_by(year: year - 1, week_number: get_latest_week_number_of_a_year(year - 1))
+    else
+      Planning.find_by(year: year, week_number: week_number)
+    end
+  end
+
+  def get_next_week_planning
+    # => id du planning de la semaine suivante
+    if week_number == get_latest_week_number_of_a_year(year)
+      Planning.find_by(year: year + 1, week_number: 1)
+    else
+      Planning.find_by(year: year, week_number: week_number + 1)
+    end
   end
 
   def get_latest_week_number_of_a_year(year)
@@ -144,5 +189,4 @@ class Planning < ApplicationRecord
   def get_last_date_of_a_week(year, week_number)
     Date.commercial(year, week_number, 1).end_of_week
   end
-
 end

--- a/app/models/planning.rb
+++ b/app/models/planning.rb
@@ -30,6 +30,10 @@ class Planning < ApplicationRecord
     solutions.find_by(effectivity: :chosen)
   end
 
+  def has_a_chosen_solution?
+    solutions.select{ |s| s.effectivity == :chosen }.count.positive?
+  end
+
   def chosen_solution_slots
     chosen_solution.solution_slots
   end
@@ -81,6 +85,59 @@ class Planning < ApplicationRecord
 
   def seconds_in_hours(seconds)
     [seconds / 3600, seconds / 60 % 60].map { |t| t.to_s.rjust(2,'0') }.join('h')
+  end
+
+  def get_previous_week_planning
+    # => id du planning de la semaine précédente
+    if week_number == 1
+      Planning.find_by(year: year - 1, week_number: get_latest_week_number_of_a_year(year - 1))
+    else
+      Planning.find_by(year: year, week_number: week_number)
+    end
+  end
+
+  def get_next_week_planning
+    # => id du planning de la semaine suivante
+    if week_number == get_latest_week_number_of_a_year(year)
+      Planning.find_by(year: year + 1, week_number: 1)
+    else
+      Planning.find_by(year: year, week_number: week_number + 1)
+    end
+  end
+
+  def evaluate_timeframe_to_test_nb_users_six_consec_days_fail
+    if get_previous_week_planning.has_a_chosen_solution?
+      if get_next_week_planning.has_a_chosen_solution?
+        start_time = get_first_date_of_a_week(get_previous_week_planning.year,
+          get_previous_week_planning.week_number)
+        end_time = get_last_date_of_a_week(get_next_week_planning.year,
+          get_next_week_planning.week_number)
+      else
+        start_time = get_first_date_of_a_week(get_previous_week_planning.year,
+          get_previous_week_planning.week_number)
+        end_time = get_last_date_of_a_week(planning.year, planning.week_number)
+      end
+    elsif get_next_week_planning.has_a_chosen_solution?
+      start_time = get_first_date_of_a_week(year, week_number)
+      end_time = get_last_date_of_a_week(get_next_week_planning.year,
+          get_next_week_planning.week_number)
+    else
+      start_time = get_first_date_of_a_week(year, week_number)
+      end_time = get_last_date_of_a_week(year, week_number)
+    end
+    return [start_time .. end_time]
+  end
+
+  def get_latest_week_number_of_a_year(year)
+    Planning.where('year = ?', year).map(&:week_number).max
+  end
+
+  def get_first_date_of_a_week(year, week_number)
+    Date.commercial(year, week_number, 1).beginning_of_week
+  end
+
+  def get_last_date_of_a_week(year, week_number)
+    Date.commercial(year, week_number, 1).end_of_week
   end
 
 end

--- a/app/models/planning.rb
+++ b/app/models/planning.rb
@@ -106,8 +106,9 @@ class Planning < ApplicationRecord
   end
 
   def evaluate_timeframe_to_test_nb_users_six_consec_days_fail
-    if get_previous_week_planning.has_a_chosen_solution?
-      if get_next_week_planning.has_a_chosen_solution?
+
+    if !get_previous_week_planning.nil? && get_previous_week_planning.has_a_chosen_solution?
+      if !get_next_week_planning.nil? && get_next_week_planning.has_a_chosen_solution?
         start_time = get_first_date_of_a_week(get_previous_week_planning.year,
           get_previous_week_planning.week_number)
         end_time = get_last_date_of_a_week(get_next_week_planning.year,
@@ -117,7 +118,7 @@ class Planning < ApplicationRecord
           get_previous_week_planning.week_number)
         end_time = get_last_date_of_a_week(planning.year, planning.week_number)
       end
-    elsif get_next_week_planning.has_a_chosen_solution?
+    elsif !get_next_week_planning.nil? && get_next_week_planning.has_a_chosen_solution?
       start_time = get_first_date_of_a_week(year, week_number)
       end_time = get_last_date_of_a_week(get_next_week_planning.year,
           get_next_week_planning.week_number)

--- a/app/models/planning.rb
+++ b/app/models/planning.rb
@@ -128,16 +128,10 @@ class Planning < ApplicationRecord
     return [start_time .. end_time]
   end
 
-<<<<<<< HEAD
-=======
   def timeframe
     [get_first_date_of_a_week(year, week_number) .. get_last_date_of_a_week(year, week_number)]
-
   end
 
-  private
-
->>>>>>> + nb_users_daily_hours_fail
   def get_latest_week_number_of_a_year(year)
     Planning.where('year = ?', year).map(&:week_number).max
   end

--- a/app/models/planning.rb
+++ b/app/models/planning.rb
@@ -128,6 +128,16 @@ class Planning < ApplicationRecord
     return [start_time .. end_time]
   end
 
+<<<<<<< HEAD
+=======
+  def timeframe
+    [get_first_date_of_a_week(year, week_number) .. get_last_date_of_a_week(year, week_number)]
+
+  end
+
+  private
+
+>>>>>>> + nb_users_daily_hours_fail
   def get_latest_week_number_of_a_year(year)
     Planning.where('year = ?', year).map(&:week_number).max
   end

--- a/app/models/planning.rb
+++ b/app/models/planning.rb
@@ -103,6 +103,11 @@ class Planning < ApplicationRecord
     return [start_time .. end_time]
   end
 
+  def timeframe
+    [get_first_date_of_a_week(year, week_number) .. get_last_date_of_a_week(year, week_number)]
+
+  end
+
   private
 
   def get_latest_week_number_of_a_year(year)

--- a/app/models/planning.rb
+++ b/app/models/planning.rb
@@ -81,8 +81,9 @@ class Planning < ApplicationRecord
   end
 
   def evaluate_timeframe_to_test_nb_users_six_consec_days_fail
-    if get_previous_week_planning.has_a_chosen_solution?
-      if get_next_week_planning.has_a_chosen_solution?
+
+    if !get_previous_week_planning.nil? && get_previous_week_planning.has_a_chosen_solution?
+      if !get_next_week_planning.nil? && get_next_week_planning.has_a_chosen_solution?
         start_time = get_first_date_of_a_week(get_previous_week_planning.year,
           get_previous_week_planning.week_number)
         end_time = get_last_date_of_a_week(get_next_week_planning.year,
@@ -92,7 +93,7 @@ class Planning < ApplicationRecord
           get_previous_week_planning.week_number)
         end_time = get_last_date_of_a_week(planning.year, planning.week_number)
       end
-    elsif get_next_week_planning.has_a_chosen_solution?
+    elsif !get_next_week_planning.nil? && get_next_week_planning.has_a_chosen_solution?
       start_time = get_first_date_of_a_week(year, week_number)
       end_time = get_last_date_of_a_week(get_next_week_planning.year,
           get_next_week_planning.week_number)

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -81,6 +81,11 @@ class Slot < ApplicationRecord
     end
   end
 
+  def length
+    # slot duration in seconds
+    end_at - start_at
+  end
+
   def get_infos_to_reaffect_slot
     # => get infos to display in modal-reassignment
     result = []

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -65,7 +65,7 @@ class Solution < ApplicationRecord
   def employees_overtime
     employees_overtime = {}
     employees_involved.each do |employee|
-      seconds = self.solution_slots.where(user: employee).map{|ss| ss.slot.end_at - ss.slot.start_at}.reduce(:+).to_i
+      seconds = nb_seconds_worked(self, employee)
       employees_overtime[employee.first_name.capitalize] = seconds - (employee.working_hours * 3600)
     end
     employees_overtime
@@ -144,7 +144,6 @@ class Solution < ApplicationRecord
     employees_involved.each do |employee|
       dates = []
       planning.timeframe.first.each do |date| # sur toutes les dates du planning
-      binding.pry
         if employee.nb_seconds_on_duty_today(date, self)/3600 > 8 # travaille > 8h?
           dates << date
           nb_fails += 1
@@ -153,6 +152,25 @@ class Solution < ApplicationRecord
       list << { employee: employee, dates: dates } unless dates.empty?
     end
     update(nb_users_daily_hours_fail: nb_fails)
+  end
+
+  def evaluate_nb_users_in_overtime
+    # number of users where weekly hours > contract
+    result = 0
+    employees_involved.each do |employee|
+      result += 1 if nb_seconds_worked(self, employee)/3600 > employee.working_hours ?
+    end
+    update(nb_users_in_overtime: nb)
+  end
+
+  def evaluate_compactness
+    employess_involved.each do |employee|
+      # calculate nb_days_theory (integer)
+      nb_days_theory = (employee.working_hours/8.0).ceil
+      # compare with nb of days_real
+      # si |real - theory| > 0, ne pas prendre en compte, sinon prendre en compte
+    end
+    update(compactness: result)
   end
 
   private

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -69,7 +69,8 @@ class Solution < ApplicationRecord
     # { name: seconds, ... } => contractual working hours - on duty hours
     employees_overtime = {}
     employees_involved.each do |employee|
-      employees_overtime[employee.first_name.capitalize] = employee.overtime(self)
+      seconds = self.solution_slots.where(user: employee).map{|ss| ss.slot.end_at - ss.slot.start_at}.reduce(:+).to_i
+      employees_overtime[employee.first_name.capitalize] = seconds - (employee.working_hours * 3600)
     end
     employees_overtime
   end
@@ -202,13 +203,14 @@ class Solution < ApplicationRecord
     # dispos = (working_hours des employés) – (h de contraintes dures)
     # sur une plage d'ouverture (pour l'instant 9h - 20h mais TODO à renseigner par le manager)
     # calculate heures dispos
-      users.each do |user|
-        user.evaluate_nb_hours_available()
     # calculate heures du planning
     # est-ce que le planning peut être fit? hplanning <= dispos
       # sinon, calculer la deviation (%) = dispos / planning
     # calcul de planning_fitness = overtime + |undertime| / nb heures planning
     # resultat si prise en compte de la deviation ou non
+      # calculate nb_days_theory (integer)
+      # compare with nb of days_real
+      # si |real - theory| > 0, ne pas prendre en compte, sinon prendre en compte
   end
 
   private
@@ -233,7 +235,5 @@ class Solution < ApplicationRecord
   def get_planning_related_to_a_date(date)
     Planning.find_by(year: date.year, week_number: date.cweek)
   end
-
-
 
 end

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -45,6 +45,7 @@ class Solution < ApplicationRecord
   enum relevance: [:optimal, :partial]
 
   after_create :evaluate_relevance, :evaluate_nb_conflicts,:evaluate_nb_users_six_consec_days_fail, :evaluate_nb_users_daily_hours_fail, :evaluate_compactness, :evaluate_nb_users_in_overtime
+
   # nb_overlaps already given as a parameter when algo creates a solution
 
   # Note: Solution gets updated when one of its SolutionSlot is updated
@@ -232,5 +233,7 @@ class Solution < ApplicationRecord
   def get_planning_related_to_a_date(date)
     Planning.find_by(year: date.year, week_number: date.cweek)
   end
+
+
 
 end

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -45,12 +45,24 @@ class Solution < ApplicationRecord
   enum effectivity: [:not_chosen, :chosen]
   enum relevance: [:optimal, :partial]
 
-  after_create :total_over_time, :evaluate_relevance, :evaluate_nb_conflicts, :evaluate_conflicts_percentage, :evaluate_nb_users_six_consec_days_fail, :evaluate_nb_users_daily_hours_fail, :evaluate_compactness, :evaluate_nb_users_in_overtime, :evaluate_fitness
-  after_create :rate_solution
+  after_create :initialize
 
   # nb_overlaps already given as a parameter when algo creates a solution
 
   # Note: Solution gets updated when one of its SolutionSlot is updated
+  def initialize
+    # evaluate attributes and grade
+    total_over_time
+    evaluate_relevance
+    evaluate_nb_conflicts
+    evaluate_conflicts_percentage
+    evaluate_nb_users_six_consec_days_fail
+    evaluate_nb_users_daily_hours_fail
+    evaluate_compactness
+    evaluate_nb_users_in_overtime
+    evaluate_fitness
+    rate_solution
+  end
 
   def evaluate_relevance
     nb_conflicts = solution_slots.where(user: User.find_by(first_name: 'no solution')).count

--- a/app/models/solution_slot.rb
+++ b/app/models/solution_slot.rb
@@ -68,6 +68,7 @@ class SolutionSlot < ApplicationRecord
     self.solution.evaluate_nb_conflicts
     self.solution.evaluate_nb_overlaps
     self.solution.evaluate_relevance
+    self.solution.evaluate_nb_users_six_consec_days_fail
     # update planning status (maybe you resolved all conflicts)
     self.planning.set_status
     # update solution_slot (no attributes to update for now)

--- a/app/models/solution_slot.rb
+++ b/app/models/solution_slot.rb
@@ -74,6 +74,7 @@ class SolutionSlot < ApplicationRecord
     self.evaluate_nb_users_daily_hours_fail
     self.evaluate_nb_users_in_overtime
     self.evaluate_compactness
+    self.evaluate_nb_users_in_overtime
     # update solution_slot (no attributes to update for now)
     self.evaluate_nb_users_daily_hours_fail
     # update compute_solution (nb_optimal_solutions)

--- a/app/models/solution_slot.rb
+++ b/app/models/solution_slot.rb
@@ -69,6 +69,8 @@ class SolutionSlot < ApplicationRecord
     self.solution.evaluate_nb_overlaps
     self.solution.evaluate_nb_users_six_consec_days_fail
     self.evaluate_nb_users_daily_hours_fail
+    self.evaluate_nb_users_in_overtime
+    self.evaluate_compactness
     # update solution_slot (no attributes to update for now)
     # update compute_solution (nb_optimal_solutions)
     self.solution.compute_solution.evaluate_nb_optimal_solutions

--- a/app/models/solution_slot.rb
+++ b/app/models/solution_slot.rb
@@ -68,6 +68,7 @@ class SolutionSlot < ApplicationRecord
     self.solution.evaluate_nb_conflicts
     self.solution.evaluate_nb_overlaps
     self.solution.evaluate_nb_users_six_consec_days_fail
+    self.evaluate_nb_users_daily_hours_fail
     # update solution_slot (no attributes to update for now)
     # update compute_solution (nb_optimal_solutions)
     self.solution.compute_solution.evaluate_nb_optimal_solutions

--- a/app/models/solution_slot.rb
+++ b/app/models/solution_slot.rb
@@ -71,6 +71,7 @@ class SolutionSlot < ApplicationRecord
     self.evaluate_nb_users_daily_hours_fail
     self.evaluate_nb_users_in_overtime
     self.evaluate_compactness
+    self.evaluate_nb_users_in_overtime
     # update solution_slot (no attributes to update for now)
     # update compute_solution (nb_optimal_solutions)
     self.solution.compute_solution.evaluate_nb_optimal_solutions

--- a/app/models/solution_slot.rb
+++ b/app/models/solution_slot.rb
@@ -67,6 +67,7 @@ class SolutionSlot < ApplicationRecord
     self.solution.total_over_time
     self.solution.evaluate_nb_conflicts
     self.solution.evaluate_nb_overlaps
+    self.solution.evaluate_nb_users_six_consec_days_fail
     # update solution_slot (no attributes to update for now)
     # update compute_solution (nb_optimal_solutions)
     self.solution.compute_solution.evaluate_nb_optimal_solutions

--- a/app/models/solution_slot.rb
+++ b/app/models/solution_slot.rb
@@ -50,6 +50,11 @@ class SolutionSlot < ApplicationRecord
     return { nb_overlaps: nb_overlaps, overlaps_details: overlaps_details }
   end
 
+  def get_related_slot
+    # Slot instance related to this SolutionSlot
+    Slot.find(slot_id)
+  end
+
   private
 
   def no_solution_user_id

--- a/app/models/solution_slot.rb
+++ b/app/models/solution_slot.rb
@@ -72,6 +72,7 @@ class SolutionSlot < ApplicationRecord
     # update planning status (maybe you resolved all conflicts)
     self.planning.set_status
     # update solution_slot (no attributes to update for now)
+    self.evaluate_nb_users_daily_hours_fail
     # update compute_solution (nb_optimal_solutions)
     self.solution.compute_solution.evaluate_nb_optimal_solutions
   end

--- a/app/models/solution_slot.rb
+++ b/app/models/solution_slot.rb
@@ -71,6 +71,9 @@ class SolutionSlot < ApplicationRecord
     self.solution.evaluate_nb_users_six_consec_days_fail
     # update planning status (maybe you resolved all conflicts)
     self.planning.set_status
+    self.evaluate_nb_users_daily_hours_fail
+    self.evaluate_nb_users_in_overtime
+    self.evaluate_compactness
     # update solution_slot (no attributes to update for now)
     self.evaluate_nb_users_daily_hours_fail
     # update compute_solution (nb_optimal_solutions)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,6 +116,10 @@ class User < ApplicationRecord
       s.end_at >= date.to_datetime }.map{|ss| ss.slot.end_at - ss.slot.start_at}.reduce(:+).to_i
   end
 
+  def nb_seconds_worked(solution, user)
+    solution.solution_slots.where(user: user).map{|ss| ss.slot.end_at - ss.slot.start_at}.reduce(:+).to_i
+  end
+
   def is_on_duty_according_to_time_period?(start_at, end_at)
     # true if user is assigned to >0 slots on a chosen solution
     SolutionSlot.select{ |s| s.solution.effectivity == 'chosen' &&

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -110,6 +110,12 @@ class User < ApplicationRecord
       s.end_at >= date.to_datetime + 1 }.count.positive?
   end
 
+  def nb_seconds_on_duty_today(date, solution)
+    # number of seconds during which the user is on duty (for a given solution)
+    solution.solution_slots.select{ |s| s.user == self && s.start_at <= date.to_datetime + 1 &&
+      s.end_at >= date.to_datetime }.map{|ss| ss.slot.end_at - ss.slot.start_at}.reduce(:+).to_i
+  end
+
   def is_on_duty_according_to_time_period?(start_at, end_at)
     # true if user is assigned to >0 slots on a chosen solution
     SolutionSlot.select{ |s| s.solution.effectivity == 'chosen' &&

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -120,6 +120,12 @@ class User < ApplicationRecord
     solution.solution_slots.where(user: user).map{|ss| ss.slot.end_at - ss.slot.start_at}.reduce(:+).to_i
   end
 
+  def overtime(solution)
+    # overtime for a user and a solution (integer, seconds)
+    seconds = nb_seconds_worked(solution, self)
+    seconds - (self.working_hours * 3600)
+  end
+
   def is_on_duty_according_to_time_period?(start_at, end_at)
     # true if user is assigned to >0 slots on a chosen solution
     SolutionSlot.select{ |s| s.solution.effectivity == 'chosen' &&

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,7 +61,24 @@ class User < ApplicationRecord
   end
 
   def available?(start_at, end_at)
+    # true if user has no constraint during a given timeframe
     constraints.where('start_at <= ? and end_at >= ?', end_at, start_at).empty?
+  end
+
+  def availability_in_hours(planning)
+    # heures d'ouverture - contraintes. TODO : heures d'ouverture à renseigner par le manager VS actuellement 9h - 20h
+    availability_user_hours = 11 * planning.number_of_days # 11 = de 9h à 20h mais à modifier ensuite (propriété du planning)
+    planning.list_of_days.each do |date|
+      duration = 0
+      start_timeframe = DateTime.new(date.year, date.month, date.day, 9)
+      end_timeframe = DateTime.new(date.year, date.month, date.day, 20)
+      constraints.where('start_at <= ? and end_at >= ? and category != ?',
+        end_timeframe, start_timeframe, Constraint.categories['preference']).each do |constraint|
+        duration = constraint_duration_according_to_timeframe(constraint, 9, 20)
+        availability_user_hours -= duration
+      end
+    end
+    availability_user_hours
   end
 
   def skilled_and_available?(start_at, end_at, role_id)
@@ -137,4 +154,25 @@ class User < ApplicationRecord
     # TODO => add attribute in user model
     on_duty_hours_decimal < 8 ? true : false
   end
+
+  def constraint_duration_according_to_timeframe(constraint, start_hour_f, end_hour_f)
+    # intersection in hours (float) between constraint & opening hours
+    constraint_start_hours = constraint.start_at.hour + constraint.start_at.strftime('%M').to_i/60.to_f
+    constraint_end_hours = constraint.end_at.hour + constraint.end_at.strftime('%M').to_i/60.to_f
+    if constraint_start_hours <= start_hour_f && constraint_end_hours >= end_hour_f
+      r = end_hour_f - start_hour_f
+    elsif constraint_start_hours < start_hour_f && constraint_end_hours <= end_hour_f
+      r = constraint_end_hours - start_hour_f
+    elsif constraint_end_hours > end_hour_f && contraint_start_hours >= start_hour_f
+      r = end_hour_f - constraint_start_hours
+    elsif constraint_start_hours >= start_hour_f && constraint_end_hours <= end_hour_f
+      r = constraint_end_hours - constraint_start_hours
+    else
+      r = "attention! cas non prévu!"
+    end
+    r
+  end
+
+  private
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -100,8 +100,14 @@ class User < ApplicationRecord
 
   def is_on_duty?(planning, slot)
     # true if is assigned to another solution_slot intersecting this slot
-    planning.chosen_solution.solution_slots.select{ |s| s.start_at <= slot.end_at &&
-      s.end_at >= slot.start_at && s.user == self }.count.positive?
+    planning.chosen_solution.solution_slots.select{ |s| s.user == self &&
+      s.start_at <= slot.end_at && s.end_at >= slot.start_at }.count.positive?
+  end
+
+  def works_today?(date, solution)
+    # true if the user is on duty for a specific day and solution
+    solution.solution_slots.select{ |s| s.user == self && s.start_at <= date.to_datetime &&
+      s.end_at >= date.to_datetime + 1 }.count.positive?
   end
 
   def is_on_duty_according_to_time_period?(start_at, end_at)

--- a/app/services/go_find_solutions_v1_service.rb
+++ b/app/services/go_find_solutions_v1_service.rb
@@ -316,16 +316,18 @@ def pick_best_solutions(solutions_array, how_many_solutions_do_we_store)
       @compute_solution.calcul_solution_v1.slotgroups_array.each do |slotgroup|
         slotgroup.overlaps.each do |overlaps| # overlaps => [ {}, {},... ]
           # mettre les users du sg overlappé en overlap à no solution
-          users_overlapped_sg = planning_possibility.select{ |h| h[:sg_id] == overlaps[:slotgroup_id] }.first[:combination] # => Array of users'ids
-          users_initial_sg = planning_possibility.select{ |h| h[:sg_id] == slotgroup.id }.first[:combination]
-          users_overlapped_sg.each do |user|
-            if users_initial_sg.include?(user) # ce user est en overlap
-              planning_possibility_hash = planning_possibility.select{ |h| h[:sg_id] == overlaps[:slotgroup_id] }.first
-              # get index of user in overlapped sg combination
-              index_user_to_replace = planning_possibility_hash[:combination].index(user)
-              replace_user_in_planning_possibility_hash(planning_possibility_hash, index_user_to_replace)
-              # binding.pry
-              evaluate_overlaps_for_a_planning(planning_possibility, 0)
+          # /!\ SSI ce slotgroup est présent càd est à simuler!
+          unless planning_possibility.select{ |h| h[:sg_id] == overlaps[:slotgroup_id] }.empty? || planning_possibility.select{ |h| h[:sg_id] == slotgroup.id }.empty?
+            users_overlapped_sg = planning_possibility.select{ |h| h[:sg_id] == overlaps[:slotgroup_id] }.first[:combination] # => Array of users'ids
+            users_initial_sg = planning_possibility.select{ |h| h[:sg_id] == slotgroup.id }.first[:combination]
+            users_overlapped_sg.each do |user|
+              if users_initial_sg.include?(user) # ce user est en overlap
+                planning_possibility_hash = planning_possibility.select{ |h| h[:sg_id] == overlaps[:slotgroup_id] }.first
+                # get index of user in overlapped sg combination
+                index_user_to_replace = planning_possibility_hash[:combination].index(user)
+                replace_user_in_planning_possibility_hash(planning_possibility_hash, index_user_to_replace)
+                evaluate_overlaps_for_a_planning(planning_possibility, 0)
+              end
             end
           end
         end

--- a/app/views/compute_solutions/_list_computed_solutions.erb
+++ b/app/views/compute_solutions/_list_computed_solutions.erb
@@ -69,6 +69,9 @@
               <div class="list-group-item sol-item <%= "chosen" if solution.chosen? %>">
                 <div class="sol-status label label-caplan">#<%= index + 1 %></div>
                 <div class="sol-details">
+                  <% unless solution.grade.nil? %>
+                  <strong>Note: <span class="badge badge-red"><%= solution.grade %></span></strong>
+                  <% end %>
                   <strong> Indice de pertinence <span class="badge badge-blue" ><%= solution.relevance %></span></strong>
                   <% unless (solution.nb_conflicts.nil? || solution.nb_conflicts.zero?)  %>
 

--- a/db/migrate/20180525094316_add_ranking_columns_to_solution.rb
+++ b/db/migrate/20180525094316_add_ranking_columns_to_solution.rb
@@ -1,0 +1,8 @@
+class AddRankingColumnsToSolution < ActiveRecord::Migration[5.0]
+  def change
+    add_column :solutions, :nb_users_six_consec_days_fail, :integer
+    add_column :solutions, :nb_users_daily_hours_fail, :integer
+    add_column :solutions, :compactness, :integer
+    add_column :solutions, :nb_users_in_overtime, :integer
+  end
+end

--- a/db/migrate/20180709084812_add_columns_for_ranking_to_solution.rb
+++ b/db/migrate/20180709084812_add_columns_for_ranking_to_solution.rb
@@ -2,5 +2,6 @@ class AddColumnsForRankingToSolution < ActiveRecord::Migration[5.0]
   def change
     add_column :solutions, :conflicts_percentage, :decimal
     add_column :solutions, :fitness, :decimal
+    add_column :solutions, :grade, :decimal
   end
 end

--- a/db/migrate/20180709084812_add_columns_for_ranking_to_solution.rb
+++ b/db/migrate/20180709084812_add_columns_for_ranking_to_solution.rb
@@ -1,0 +1,6 @@
+class AddColumnsForRankingToSolution < ActiveRecord::Migration[5.0]
+  def change
+    add_column :solutions, :conficts_percentage, :decimal
+    add_column :solutions, :planning_fitness, :decimal
+  end
+end

--- a/db/migrate/20180709084812_add_columns_for_ranking_to_solution.rb
+++ b/db/migrate/20180709084812_add_columns_for_ranking_to_solution.rb
@@ -1,6 +1,6 @@
 class AddColumnsForRankingToSolution < ActiveRecord::Migration[5.0]
   def change
-    add_column :solutions, :conficts_percentage, :decimal
-    add_column :solutions, :planning_fitness, :decimal
+    add_column :solutions, :conflicts_percentage, :decimal
+    add_column :solutions, :fitness, :decimal
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -158,8 +158,8 @@ ActiveRecord::Schema.define(version: 20180709084812) do
     t.integer  "nb_users_daily_hours_fail"
     t.integer  "compactness"
     t.integer  "nb_users_in_overtime"
-    t.decimal  "conficts_percentage"
-    t.decimal  "planning_fitness"
+    t.decimal  "conflicts_percentage"
+    t.decimal  "fitness"
     t.index ["compute_solution_id"], name: "index_solutions_on_compute_solution_id", using: :btree
     t.index ["planning_id"], name: "index_solutions_on_planning_id", using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180612133352) do
+ActiveRecord::Schema.define(version: 20180709084812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "algo_stats", force: :cascade do |t|
+    t.integer  "nb_compute_solutions"
+    t.integer  "nb_solutions"
+    t.integer  "nb_fail"
+    t.float    "go_through_solutions_mean_time_per_slot"
+    t.float    "solutions_storing_mean_time"
+    t.float    "tree_covered_mean"
+    t.float    "total_mean_time"
+    t.datetime "created_at",                              null: false
+    t.datetime "updated_at",                              null: false
+  end
 
   create_table "attachinary_files", force: :cascade do |t|
     t.string   "attachinariable_type"
@@ -51,8 +63,8 @@ ActiveRecord::Schema.define(version: 20180612133352) do
   create_table "compute_solutions", force: :cascade do |t|
     t.integer  "status"
     t.integer  "planning_id"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.datetime "created_at",                              null: false
+    t.datetime "updated_at",                              null: false
     t.integer  "nb_solutions"
     t.integer  "nb_optimal_solutions"
     t.integer  "nb_iterations"
@@ -65,6 +77,11 @@ ActiveRecord::Schema.define(version: 20180612133352) do
     t.text     "team"
     t.text     "p_list_of_slots_ids"
     t.text     "timestamps_algo"
+    t.float    "go_through_solutions_mean_time_per_slot"
+    t.float    "solution_storing_mean_time_per_slot"
+    t.float    "mean_time_per_slot"
+    t.text     "fail_level"
+    t.float    "percent_tree_covered"
     t.index ["planning_id"], name: "index_compute_solutions_on_planning_id", using: :btree
   end
 
@@ -141,6 +158,8 @@ ActiveRecord::Schema.define(version: 20180612133352) do
     t.integer  "nb_users_daily_hours_fail"
     t.integer  "compactness"
     t.integer  "nb_users_in_overtime"
+    t.decimal  "conficts_percentage"
+    t.decimal  "planning_fitness"
     t.index ["compute_solution_id"], name: "index_solutions_on_compute_solution_id", using: :btree
     t.index ["planning_id"], name: "index_solutions_on_planning_id", using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180411153811) do
+ActiveRecord::Schema.define(version: 20180525094316) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 20180411153811) do
     t.string   "p_nb_hours"
     t.text     "p_nb_hours_roles"
     t.text     "team"
+    t.text     "p_list_of_slots_ids"
     t.index ["planning_id"], name: "index_compute_solutions_on_planning_id", using: :btree
   end
 
@@ -127,12 +128,16 @@ ActiveRecord::Schema.define(version: 20180411153811) do
     t.integer  "nb_extra_hours"
     t.integer  "planning_id"
     t.integer  "compute_solution_id"
-    t.integer  "effectivity",         default: 0
+    t.integer  "effectivity",                   default: 0
     t.integer  "relevance"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.datetime "created_at",                                null: false
+    t.datetime "updated_at",                                null: false
     t.integer  "nb_conflicts"
     t.integer  "nb_under_hours"
+    t.integer  "nb_users_six_consec_days_fail"
+    t.integer  "nb_users_daily_hours_fail"
+    t.integer  "compactness"
+    t.integer  "nb_users_in_overtime"
     t.index ["compute_solution_id"], name: "index_solutions_on_compute_solution_id", using: :btree
     t.index ["planning_id"], name: "index_solutions_on_planning_id", using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -160,6 +160,7 @@ ActiveRecord::Schema.define(version: 20180709084812) do
     t.integer  "nb_users_in_overtime"
     t.decimal  "conflicts_percentage"
     t.decimal  "fitness"
+    t.decimal  "grade"
     t.index ["compute_solution_id"], name: "index_solutions_on_compute_solution_id", using: :btree
     t.index ["planning_id"], name: "index_solutions_on_planning_id", using: :btree
   end


### PR DESCRIPTION
## Evaluation d'une Solution en lui attribuant une note /100
5 critères pour l'instant  
- %durée conflits
- respect règle des 6 jours
- respect du temps de travail journalier
- "planning fitness"
- compacité

La note et ses attributs sont stockés dans le modèle Solution

Selon[ le bareme actuel ](https://app.nuclino.com/Ca-Plan-Pour-Moi/Main/Ranking-solutions-426f497f-8f7c-4270-a4d0-748f7c949b1b) on attribue une note /42 que l'on transforme ensuite /100.

Cette note est affichée dans l'index des ComputeSolution
![screenshot from 2018-07-11 12-42-39](https://user-images.githubusercontent.com/29304869/42566946-8e3442a6-8508-11e8-88e2-b6c349b25103.png)

## Comment on fait
- à la suite de go_through_plannings, on se retrouve avec une liste de solutions +/- longue qui est stockée dans solutions_array
- lorsque l'on stocke chaque solution de ce solutions_array, on passe par la method init du modèle Solution qui permet d'évaluer les paramètres de la solution puis de calculer la note
- la note est ensuite stockée

Problème : cela suppose que l'on doit stocker la solution pour en obtenir la note... ce que nous souhaiterions éviter (voir next steps).

## Next steps
- Intégrer ce grading à chaque itération de l'algo => si grade < best on ne push pas la solution dans solutions_array. solutions_array pourrait ainsi n'être composé d'un seul élément (le best).


- réfléchir à la définition de planning_fitness (il y a sûrement mieux...)

