### PR TITLE
fixed

### DIFF
--- a/app/assets/javascripts/components/calendar-constraints.js
+++ b/app/assets/javascripts/components/calendar-constraints.js
@@ -87,6 +87,7 @@ $('#calendar').fullCalendar({
   events: events,
   // what happens when we select a time period on the calendar
   select: function( start, end, jsEvent, view ) {
+    $('.category').removeClass("checked");
     var modalContent = document.querySelector(".modal-constraint");
     modalPosition(modalContent, jsEvent.clientY);
     $(".modal-constraint").modal('show');
@@ -95,20 +96,20 @@ $('#calendar').fullCalendar({
     $('.delete_constraint').hide();
     $('.days-list').show();
     // set default value of the date inputs (inside simple form)
-    $('#datetimepicker1 .form-control').val(new Date(start.format()).toLocaleDateString('fr-FR', {timezone: 'UTC', hour: '2-digit', minute: '2-digit'}));
     $('#datetimepicker1').datetimepicker({
       locale: 'FR'
      });
+    $('#datetimepicker1 .form-control').val(new Date(start.format()).toLocaleDateString('fr-FR', {timezone: 'UTC', hour: '2-digit', minute: '2-digit'}));
     $('#datetimepicker2 .form-control').val(new Date(end.format()).toLocaleDateString('fr-FR', {timezone: 'UTC', hour: '2-digit', minute: '2-digit'}));
     $('#datetimepicker2').datetimepicker({
       locale: 'FR'
      });
     // comportement lors de la sélection d'une catégorie
     $('.category').click( function (data){
-      $('#0').removeClass("checked");
-      $('#1').removeClass("checked");
-      $('#2').removeClass("checked");
-      $(this).addClass("checked");
+      $('#0').removeClass('checked');
+      $('#1').removeClass('checked');
+      $('#2').removeClass('checked');
+      $(this).toggleClass('checked');
     });
     //behavior of days sélection
     $("input:checkbox").click(function(){

--- a/app/controllers/constraints_controller.rb
+++ b/app/controllers/constraints_controller.rb
@@ -12,7 +12,9 @@ class ConstraintsController < ApplicationController
   def create
     @user = User.find(params[:user_id])
     constraint_model = Constraint.new(constraint_params)
-    constraint_model.update(user_id: @user.id, category: params[:category].first.to_i)
+    unless params[:category].nil?
+      constraint_model.update(user_id: @user.id, category: params[:category].first.to_i)
+    end
     constraint_list = []
     @constraints
     clicked_day = constraint_params[:start_at].to_datetime.strftime("%u").to_i
@@ -34,8 +36,10 @@ class ConstraintsController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit }
+        @errors = constraint_list.select{|s| s.errors.messages != nil}.first.errors.messages.values.flatten.join(" + ")
+        @constraint = Constraint.new
         format.js
+        format.html
       end
     end
   end

--- a/app/views/constraints/_form.html.erb
+++ b/app/views/constraints/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for [@user], :url => user_constraints_path(@user), :method => :post do |f| %>
+<%= simple_form_for [@user], :url => user_constraints_path(@user), :method => :post, :html => {:remote => true } do |f| %>
   <%= f.error_notification %>
   <div class="row">
     <div class="col-xs-12">
@@ -24,7 +24,7 @@
   </div>
   <div class="form-group">
     <ul class="list-inline categories">
-      <% @constraint_categories.each do |type, number| %>
+      <% Constraint.categories.each do |type, number| %>
       <li>
         <div class="daysbox col-xs-3 category <%= type %>" id=<%= number %>>
           <label>
@@ -66,3 +66,10 @@
     </div>
   </div>
 <% end %>
+
+<script>
+  var errors = '<%= @errors %>';
+if (errors) {
+  $('.modal-body').prepend("<b class='errors' style='color: red;'>Can't create constraint because: " + errors+ "</b>");
+  }
+</script>

--- a/app/views/constraints/create.js.erb
+++ b/app/views/constraints/create.js.erb
@@ -1,2 +1,10 @@
-$(".constraint_form").hide();
 $('#calendar').fullCalendar( 'refetchEvents');
+
+var errors = '<%= @errors %>';
+if (errors) {
+  $('.modal-body').prepend("<b class='errors' style='color: red;'>Can't create constraint because: " + errors+ "</b>");
+} else {
+  $(".constraint_form").hide();
+  $('#calendar').fullCalendar( 'refetchEvents');
+  $(".modal-events").modal('hide');
+}

--- a/app/views/slots/create.html.erb
+++ b/app/views/slots/create.html.erb
@@ -1,1 +1,0 @@
-<%= render 'form', slot: Slot.new %>

--- a/app/views/users/_html_constraints_cal.html.erb
+++ b/app/views/users/_html_constraints_cal.html.erb
@@ -1,17 +1,7 @@
 <div id = "calendar">
 </div>
 
-<div class="modal fade modal-constraint modal-events constraint_form" tabindex="-1" role="dialog">
-  <div class="modal-content">
-    <div class="modal-header">
-      <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-      <h4 class="modal-title">Ajouter une contrainte</h4>
-    </div>
-    <div class="modal-body">
-        <%= render 'constraints/form', locals: {planning: @planning, slot: @slot} %>
-    </div>
-  </div>
-</div>
+
 
 <%= javascript_include_tag "components/calendar-constraints" %>
 <%= content_for(:after_js) do %>

--- a/app/views/users/_user_infos.html.erb
+++ b/app/views/users/_user_infos.html.erb
@@ -33,6 +33,18 @@
   </div>
 </div>
 
+<div class="modal fade modal-constraint modal-events constraint_form" tabindex="-1" role="dialog">
+  <div class="modal-content">
+    <div class="modal-header">
+      <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+      <h4 class="modal-title">Ajouter une contrainte</h4>
+    </div>
+    <div class="modal-body">
+        <%= render 'constraints/form', locals: {planning: @planning, slot: @slot} %>
+    </div>
+  </div>
+</div>
+
 <div class="modal fade modal-update-constraint modal-events" tabindex="-1" role="dialog">
   <div class="modal-content">
     <div class="modal-header">


### PR DESCRIPTION
_2/ Lorsqu'on choisit un type d'indispo, impossible de désélectionner ou changer : je pense qu'il faudrait utiliser une input type radio qui permet de ne sélectionner qu'un à la fois et qui fait automatiquement les toggle blabla._
=> JS du 'checked' pour créer une contrainte => la modal 'create-constraints' n'était pas dans le bon partial donc le JS ne s'appliquait pas dessus

_1/ Lorsqu'on clique sur le calendrier, la modal s'ouvre mais ce n'est pas possible de changer la date avec les petits calendrier bootstrap_
 => pb syntax dans la déclaration

J'en ai profité pour ajouter un blocage comme pour le slots:create dans le cas où on cherche à créer une contrainte sans sélectionner de category 