### PR TITLE
add planning to google/etc...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,9 @@ gem 'fullcalendar-rails'
 gem 'momentjs-rails'
 gem 'bootstrap3-datetimepicker-rails', '~> 4.17.47'
 
+# ical
+gem "icalendar"
+
 gem 'faker'
 
 #Authentification Devise

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,9 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
+    icalendar (2.5.1)
+      ice_cube (~> 0.16)
+    ice_cube (0.16.3)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -329,6 +332,7 @@ DEPENDENCIES
   font-awesome-sass
   fullcalendar-rails
   google_charts
+  icalendar
   jbuilder (~> 2.0)
   jquery-fileupload-rails
   jquery-rails
@@ -362,4 +366,4 @@ RUBY VERSION
    ruby 2.3.4p301
 
 BUNDLED WITH
-   1.16.0
+   1.17.1

--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -23,6 +23,8 @@ padding: 5px;
   color: $myyellow;
   text-align:center;
   transition: all 0.25s ease;
+  border-radius: 10px;
+  padding: 5px;
 
   &:hover {
     background-color:$myyellow;

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -49,7 +49,7 @@ class Slot < ApplicationRecord
   end
 
   def chosen_solution
-    solutions.find_by(effectivity: :chosen)
+    solutions.chosen.first
   end
 
   def initialize_slot_hash

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -188,7 +188,7 @@ class Solution < ApplicationRecord
     # number of users where weekly hours > contract
     result = 0
     employees_involved.each do |employee|
-      result += 1 if nb_seconds_worked(self, employee)/3600 > employee.working_hours
+      result += 1 if employee.nb_seconds_worked(self) /3600 > employee.working_hours
     end
     update(nb_users_in_overtime: nb)
   end

--- a/app/models/solution_slot.rb
+++ b/app/models/solution_slot.rb
@@ -50,11 +50,6 @@ class SolutionSlot < ApplicationRecord
     return { nb_overlaps: nb_overlaps, overlaps_details: overlaps_details }
   end
 
-  def get_related_slot
-    # Slot instance related to this SolutionSlot
-    Slot.find(slot_id)
-  end
-
   private
 
   def no_solution_user_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,7 @@
 #  invited_by_type        :string
 #  invited_by_id          :integer
 #  invitations_count      :integer          default(0)
+#  key                    :string
 #
 # Indexes
 #
@@ -52,6 +53,7 @@ class User < ApplicationRecord
   has_many :solution_slots
   has_attachment :profile_picture
   scope :active, -> { where.not(first_name: "no solution").order(:first_name) }
+  before_create :set_key
 
   def concatenate_first_and_last_name
     first_name + ' ' + last_name
@@ -134,14 +136,13 @@ class User < ApplicationRecord
       s.end_at >= date.to_datetime }.map{|ss| ss.slot.end_at - ss.slot.start_at}.reduce(:+).to_i
   end
 
-  def nb_seconds_worked(solution, user)
-    solution.solution_slots.where(user: user).map{|ss| ss.slot.end_at - ss.slot.start_at}.reduce(:+).to_i
+  def nb_seconds_worked(solution)
+    solution.solution_slots.where(user: self).map{|ss| ss.slot.end_at - ss.slot.start_at}.reduce(:+).to_i
   end
 
   def overtime(solution)
     # overtime for a user and a solution (integer, seconds)
-    seconds = nb_seconds_worked(solution, self)
-    seconds - (self.working_hours * 3600)
+    nb_seconds_worked(solution) - working_hours * 3600
   end
 
   def is_on_duty_according_to_time_period?(start_at, end_at)
@@ -172,6 +173,10 @@ class User < ApplicationRecord
       r = "attention! cas non prévu!"
     end
     r
+  end
+
+  def set_key
+    self.key = SecureRandom.hex(20)
   end
 
   private

--- a/app/policies/planning_policy.rb
+++ b/app/policies/planning_policy.rb
@@ -41,4 +41,8 @@ class PlanningPolicy < ApplicationPolicy
     user.is_owner
   end
 
+  def ical?
+    true
+  end
+
 end

--- a/app/views/plannings/ical.html.erb
+++ b/app/views/plannings/ical.html.erb
@@ -1,0 +1,17 @@
+<h1>Ical Planning <%= @user.first_name %></h1>
+<div class="mb+" style="display:flex">
+
+  <%= link_to "Add to calendar", ical_plannings_url(protocol: :webcal, format: :ics, key: "#{current_user.key}"), class:"mybtn mr+"%>
+  <%= link_to "test", ical_plannings_url(key:   "#{current_user.key}"), class:"mybtn" %>
+</div>
+  <table class="table table-striped">
+      <% @slots.each do |slot| %>
+        <tr>
+          <td>start: <%= slot.start_at %></td>
+          <td>end: <%= slot.end_at %></td>
+          <td>role: <%= slot.role.name %></td>
+          <td>summary : <%= "#{slot.role.name} ##{slot.length / 3600}h" %></td>
+        </tr>
+      <% end %>
+
+  </table>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,7 +3,7 @@
   <div class="col-xs-2 edit-profile-picture pointer">
     <%= avatar_with_border_color(@user) %>
   </div>
-  <div class="col-xs-10 name">
+  <div class="col-xs-8 name">
     <ul class="list-inline" style="text-align:left">
       <li><h1> <%= @user.first_name&.capitalize %> </h1></li>
       <li><span class="fa fa-pencil modify-profile pointer" data-input="user_first_name"></span></li>
@@ -13,6 +13,9 @@
       <li><h1> <%= @user.last_name&.capitalize %></h1></li>
       <li><span class="fa fa-pencil modify-profile pointer" data-input="user_last_name"></span></li>
     </ul>
+  </div>
+  <div class="col-xs-2">
+    <%= link_to "Add to calendar", ical_plannings_url(protocol: :webcal, format: :ics, key: "#{@user.key}"), class:"mybtn mybtn-medium"%>
   </div>
 </div>
 <%= render "user_infos" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,9 @@ Rails.application.routes.draw do
   root to: 'pages#home'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   resources :plannings, only: [:show, :index, :update, :create] do
+    collection do
+      get '/ical', to: 'plannings#ical', as: 'ical'
+    end
     resources :slots, only: [:create, :edit, :show, :update, :resolve, :new, :destroy]
     resources :compute_solutions, only: [:index, :create]
     resources :solution_slots, only: [:edit, :update]
@@ -92,6 +95,7 @@ Rails.application.routes.draw do
   get 'plannings/:id/conflicts', to: 'plannings#conflicts', as: 'planning_conflicts'
   get 'plannings/:planning_id/compute_solution/:compute_solution_id', to: 'compute_solutions#show_calculation_details', as: 'show_cs_details'
   get 'plannings/:id/use_template/:planning_id', to: 'plannings#use_template', as: 'planning_use_template'
+
 
   resources :users, only: [:index, :show, :create, :new, :update] do
     resources :constraints, only: [:new, :create, :edit, :update, :destroy]

--- a/db/migrate/20181206120801_add_key_to_users.rb
+++ b/db/migrate/20181206120801_add_key_to_users.rb
@@ -1,0 +1,5 @@
+class AddKeyToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180709084812) do
+ActiveRecord::Schema.define(version: 20181206120801) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -199,6 +199,7 @@ ActiveRecord::Schema.define(version: 20180709084812) do
     t.string   "invited_by_type"
     t.integer  "invited_by_id"
     t.integer  "invitations_count",      default: 0
+    t.string   "key"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true, using: :btree
     t.index ["invitations_count"], name: "index_users_on_invitations_count", using: :btree

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -27,6 +27,7 @@
 #  invited_by_type        :string
 #  invited_by_id          :integer
 #  invitations_count      :integer          default(0)
+#  key                    :string
 #
 # Indexes
 #


### PR DESCRIPTION
URL format ICAL pour permettre d'afficher un calendrier par employé dans une application tierce : 
on affiche la durée du créneaux, le nombre d'heure semaine, nb d'heures mois etl e nb d'heures réalisées dans le mois.
Pour l'ajouter il suffit d'aller dans son profil et appuyer sur le bouton add calendar.
L'url contient un code aléatoire par utilisateur pour rendre le calendrier confidentiel.
Améliorations
--> revoir les infos de chaque créneaux
--> permettre de changer le code utilisateur
--> permettre la syncrho d'un planning d'équipe.