### PR TITLE
180 affichage de solution

### DIFF
--- a/app/models/calcul_solution_v1.rb
+++ b/app/models/calcul_solution_v1.rb
@@ -42,38 +42,34 @@ class CalculSolutionV1 < ApplicationRecord
     best_solution = nil
     calculation_abstract = nil
     initialized_slots_array = initialize_slots_array(slots) # step 1
-    CreateSlotgroupsService.new(initialized_slots_array, planning, self).perform # step 2
+
+    CreateSlotgroupsService.new(slots_array: initialized_slots_array,
+                                planning: planning,
+                                calcul_solution_v1_instance: self).perform # step 2
+    slots_not_to_simulate = get_slots_not_to_simulate(slotgroups_array, initialized_slots_array)
     to_simulate_slotgroups_array = select_slotgroups_to_simulate(self.slotgroups_array) # step 3
     need_a_calcul = to_simulate_slotgroups_array.empty? ? false : true
     if need_a_calcul # there are some sg to simulate (case 1)
       # step 4: go through plannings possibilities, assess them, select best solution. (2 cases)
       puts 'GoFindSolutionsV1Service --> initiated'
-      build_solutions = GoFindSolutionsV1Service.new(planning,
-                                                     to_simulate_slotgroups_array,
-                                                     self.compute_solution).perform
+      build_solutions = GoFindSolutionsV1Service.new(planning: planning,
+                                                     slotgroups_array: to_simulate_slotgroups_array,
+                                                     compute_solution: self.compute_solution).perform
       # build_solutions = [ {calculation_abstract}, [ [:sg_id, :combination], [...] ] ]
       puts 'GoFindSolutionsV1Service --> done. --> storing best solution'
-      # update return variables
-      # Let's not memorize this to make the Algo LEANER
-      # test_possibilities = build_solutions[:test_possibilities]
-      # Let's not memorize this to make the Algo LEANER
-      # solutions_array = build_solutions[:solutions_array]
-      # best_solution = build_solutions[1]
       calculation_abstract = build_solutions[0]
       # save calculation abstract in ComputeSolution instance
       compute_solution.save_calculation_abstract(calculation_abstract)
     end
     # Créer Solutions et SolutionSlots associées
     list_of_solutions = need_a_calcul ? build_solutions[1] : nil
-    SaveSolutionsAndSolutionSlotsService.new( self.slotgroups_array,
-      self.slots_array, planning, compute_solution, list_of_solutions ).perform
+    SaveSolutionsAndSolutionSlotsService.new( slotgroups_array: self.slotgroups_array,
+                                              slots_array: self.slots_array,
+                                              planning: planning,
+                                              compute_solution: compute_solution,
+                                              list_of_solutions: list_of_solutions,
+                                              slots_not_to_simulate: slots_not_to_simulate ).perform
     puts 'SaveSolutionsAndSolutionSlotsService --> done'
-    # Let's not memorize this to make the Algo LEANER
-    # { calcul_arrays: calcul_arrays,
-    #   test_possibilities: test_possibilities,
-    #   solutions_array: solutions_array,
-    #   best_solution: best_solution,
-    #   calculation_abstract: calculation_abstract }
   end
 
   def initialize_slots_array(slots)
@@ -110,6 +106,20 @@ class CalculSolutionV1 < ApplicationRecord
     solutions_array.each do |solution|
       solution.evaluate_relevance
     end
+  end
+
+  def get_slots_not_to_simulate(slotgroups_array, initialized_slots_array)
+    # put aside all the slots which do not need a calcul (no solution)
+    # pour pouvoir créer les solution_slots associés à no_solution
+    r = []
+    slotgroups_array.select{ |x| x.simulation_status == false }.each do |slotgroup|
+      r << similar_slots(slotgroup.id, initialized_slots_array).map{ |h| h[:slot_id] }
+    end
+    r.flatten
+  end
+
+  def similar_slots(slotgroup_id, initialized_slots_array)
+    initialized_slots_array.select { |x| x[:slotgroup_id] == slotgroup_id }
   end
 end
 

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -69,6 +69,7 @@ class Solution < ApplicationRecord
     # puts "fitness = #{self.fitness}"
     # puts "**********************************"
     rate_solution(deviation_for_fitness)
+    self # renvoyer l'instance pour la récupérer dans SaveSolutionsAndSoltionSlotsService
   end
 
   def evaluate_relevance

--- a/app/services/create_slotgroups_service.rb
+++ b/app/services/create_slotgroups_service.rb
@@ -7,11 +7,11 @@
 class CreateSlotgroupsService
   attr_accessor :slots_array, :planning, :users, :calcul, :slotgroups_array
 
-  def initialize(slots_array, planning, calcul_solution_v1_instance)
-    @slots_array = slots_array # [ {} , {} ]
-    @planning = planning
+  def initialize( attributes = {} )
+    @slots_array = attributes[:slots_array] # [ {} , {} ]
+    @planning = attributes[:planning]
     @users = @planning.users
-    @calcul = calcul_solution_v1_instance
+    @calcul = attributes[:calcul_solution_v1_instance]
   end
 
   # rubocop:disable AbcSize
@@ -38,7 +38,7 @@ class CreateSlotgroupsService
     # timestamps t3
     t = @calcul.compute_solution.timestamps_algo << ["t3", Time.now]
     @calcul.compute_solution.update(timestamps_algo: t)
-    # { slotgroups_array: slotgroups_array, slots_array: slots_array }
+    # return les slotgroups qui ne sont pas à simuler
   end
 
   # rubocop:enable AbcSize

--- a/app/services/go_find_solutions_v1_service.rb
+++ b/app/services/go_find_solutions_v1_service.rb
@@ -11,10 +11,10 @@ class GoFindSolutionsV1Service
 
   require 'csv'
 
-  def initialize(planning, slotgroups_array, compute_solution_instance)
-    @slotgroups_array = slotgroups_array
-    @planning = planning
-    @compute_solution = compute_solution_instance
+  def initialize( attributes = {} )
+    @slotgroups_array = attributes[:slotgroups_array]
+    @planning = attributes[:planning]
+    @compute_solution = attributes[:compute_solution]
     @no_solution_user_id = determine_no_solution_user.id
     @employees_involved = @planning.users # Array of users
     # stocker plannings et solutions previous/next pour DRY - sert au grading

--- a/app/services/save_solutions_and_solution_slots_service.rb
+++ b/app/services/save_solutions_and_solution_slots_service.rb
@@ -8,7 +8,7 @@ class SaveSolutionsAndSolutionSlotsService
     @planning = attributes[:planning]
     @compute_solution = attributes[:compute_solution] || nil
     @list_of_solutions = attributes[:list_of_solutions] || nil
-    @no_solution_user = [User.find_by(first_name: 'no solution').id]
+    @no_solution_user_id = User.find_by(first_name: 'no solution').id
     @slots_not_to_simulate = attributes[:slots_not_to_simulate]
   end
 
@@ -24,7 +24,7 @@ class SaveSolutionsAndSolutionSlotsService
         solution_instance.init
       end
     else
-      # solution_instance = create_solution(@compute_solution)
+      solution_instance = create_solution
       create_solution_slots_for_a_group_of_slots(@planning.slots.pluck(:id), solution_instance)
       create_no_solution_solution_slots(@slots_not_to_simulate, solution_instance)
       solution_instance.init
@@ -101,7 +101,7 @@ class SaveSolutionsAndSolutionSlotsService
     slots_array.select { |x| x[:slotgroup_id] == slotgroup_id && x[:simulation_status] == simulation_status }
   end
 
-  def create_solution_slots_for_a_group_of_slots(slots_id_array, solution_instance, users = @no_solution_user, sequence = 0)
+  def create_solution_slots_for_a_group_of_slots(slots_id_array, solution_instance, users = [@no_solution_user_id], sequence = 0)
       return if sequence == slots_id_array.length
       create_solution_slot_instance(slots_id_array[sequence], users[sequence], solution_instance)
       create_solution_slots_for_a_group_of_slots(slots_id_array, solution_instance, users, sequence +=1)
@@ -115,7 +115,7 @@ class SaveSolutionsAndSolutionSlotsService
   def create_no_solution_solution_slots(slots_not_to_simulate, solution_instance)
     unless slots_not_to_simulate.empty?
       slots_not_to_simulate.each do |slot_id|
-        SolutionSlot.create(solution: solution_instance, :slot_id => slot_id, user_id: @no_solution_user.first)
+        SolutionSlot.create(solution: solution_instance, :slot_id => slot_id, user_id: @no_solution_user_id)
       end
     end
   end


### PR DESCRIPTION
Lié à #180 

### Problème initial
Lors du SaveSolutionsAndSolutionSlotsService
lorsqu'il existe des slots qui ne sont pas à simuler
ceux-ci ne sont pas transmis à SaveSolutionsAndSolutionSlotsService.
Donc les SolutionSlots associés ne sont jamais créés.

### résolution proposée : 
- en sortie de CreateSlotgroupsService : récupérer les id des slots pour lesquels il n'y a pas de solution
=> dans not_to_simulate_slotgroups (Array)
- dans SaveSolutionsAndSolutionSlotsService: créer les solution_slots associés, avec le user 'no solution' dans tous les cas.