### PR TITLE
fix bug doublon création solution slot [pending question]

### DIFF
--- a/app/services/go_find_solutions_v1_service.rb
+++ b/app/services/go_find_solutions_v1_service.rb
@@ -239,7 +239,7 @@ class GoFindSolutionsV1Service
         end_timeframe = DateTime.new(date.year, date.month, date.day, 20)
         employee.constraints.where('start_at <= ? and end_at >= ? and category != ?',
         end_timeframe, start_timeframe, Constraint.categories['preference']).each do |constraint|
-          duration = constraint_duration_according_to_timeframe(constraint, 9, 20)
+          duration = employee.constraint_duration_according_to_timeframe(constraint, 9, 20)
           availability_user_hours -= duration
         end
       end

--- a/app/services/save_solutions_and_solution_slots_service.rb
+++ b/app/services/save_solutions_and_solution_slots_service.rb
@@ -26,7 +26,7 @@ class SaveSolutionsAndSolutionSlotsService
     else
       solution_instance = create_solution
       create_solution_slots_for_a_group_of_slots(@planning.slots.pluck(:id), solution_instance)
-      create_no_solution_solution_slots(@slots_not_to_simulate, solution_instance)
+      # create_no_solution_solution_slots(@slots_not_to_simulate, solution_instance)
       solution_instance.init
     end
     # timestamp t7

--- a/app/services/save_solutions_and_solution_slots_service.rb
+++ b/app/services/save_solutions_and_solution_slots_service.rb
@@ -26,7 +26,6 @@ class SaveSolutionsAndSolutionSlotsService
     else
       solution_instance = create_solution
       create_solution_slots_for_a_group_of_slots(@planning.slots.pluck(:id), solution_instance)
-      # create_no_solution_solution_slots(@slots_not_to_simulate, solution_instance)
       solution_instance.init
     end
     # timestamp t7


### PR DESCRIPTION
je n'ai pas réussi à re simuler le cas qui bug.

fix autre bug=
Lorsqu'il n'y a pas de solution (=aucun sg à simuler), il créait 2x les slots (la création des slots à ne pas simuler était redondante dans ce cas car on créé déjà tous les slots du planning avec un user attribué à no solution).