### PR TITLE
Issue226 edit solslot workers outside team

### DIFF
--- a/app/assets/javascripts/components/calendar-conflicts.js
+++ b/app/assets/javascripts/components/calendar-conflicts.js
@@ -93,7 +93,5 @@ var modifyCalendar = function(events, defaultDate) {
         img.height = height;
         img.alt = alt;
       };
-
-
 }
 

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -24,4 +24,5 @@
 @import "statistics";
 @import "modal-reassignment";
 @import "modal-events";
-@import "alignments"
+@import "alignments";
+@import "sections";

--- a/app/assets/stylesheets/components/_sections.scss
+++ b/app/assets/stylesheets/components/_sections.scss
@@ -1,0 +1,7 @@
+/* Entetes de tableaux */
+.section-header {
+  background-color: $myblue;
+  color: $myyellow;
+  border-radius: 0;
+
+}

--- a/app/controllers/solution_slots_controller.rb
+++ b/app/controllers/solution_slots_controller.rb
@@ -7,7 +7,8 @@ class SolutionSlotsController < ApplicationController
   def edit
     @solution = @planning.chosen_solution
     authorize @solution_slot
-    @users_infos = @solution_slot.slot.get_infos_to_reaffect_slot
+    @users_infos = @solution_slot.slot.get_infos_to_reaffect_slot(@planning.users)
+    @other_users_infos = other_skilled_users_infos
     @slot = @solution_slot.slot
     @assigned_user = User.find(@solution_slot.user_id)
     render :layout => 'no_layout'
@@ -37,4 +38,15 @@ class SolutionSlotsController < ApplicationController
   def set_solution_slot
     @solution_slot = SolutionSlot.find(params[:id])
   end
+
+  def other_skilled_users_infos
+    # users <> team mais sont skilled. Potential backups.
+    @solution_slot.slot.get_infos_to_reaffect_slot(other_users_list).select{|u| u.values[0][:skilled] == "a" }
+  end
+
+  def other_users_list
+    # users non sélectionnés pour ce planning mais qui peuvent servir de backups
+    User.where.not(first_name: 'no solution').includes(:roles, :plannings, :teams) - @planning.users
+  end
+
 end

--- a/app/controllers/solution_slots_controller.rb
+++ b/app/controllers/solution_slots_controller.rb
@@ -8,6 +8,7 @@ class SolutionSlotsController < ApplicationController
     @solution = @planning.chosen_solution
     authorize @solution_slot
     @users_infos = @solution_slot.slot.get_infos_to_reaffect_slot(@planning.users)
+    @are_there_backups = are_there_backups?
     @other_users_infos = other_skilled_users_infos
     @slot = @solution_slot.slot
     @assigned_user = User.find(@solution_slot.user_id)
@@ -47,6 +48,11 @@ class SolutionSlotsController < ApplicationController
   def other_users_list
     # users non sélectionnés pour ce planning mais qui peuvent servir de backups
     User.where.not(first_name: 'no solution').includes(:roles, :plannings, :teams) - @planning.users
+  end
+
+  def are_there_backups?
+    # true if at least 1 backup skilled & available
+    @users_infos.select{|f| f.values[0][:skilled] == "a" && f.values[0][:status] == "available" }.count.positive?
   end
 
 end

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -86,11 +86,10 @@ class Slot < ApplicationRecord
     end_at - start_at
   end
 
-  def get_infos_to_reaffect_slot
+  def get_infos_to_reaffect_slot(users_array)
     # => get infos to display in modal-reassignment
     result = []
-    users = planning.users
-    users.each do |user|
+    users_array.each do |user|
       sub_result = {}
       status = nil #init
       # compute status
@@ -101,7 +100,7 @@ class Slot < ApplicationRecord
       else
         status = "not available" # <=> has constraints
       end
-      skilled = user.skilled?(role_id)
+      user.skilled?(role_id) ? skilled = "a" : skilled = "b"
       a = user.nb_hours_planning(planning, self) # compute nb of hours
       sub_result[user.id] = { status: status,
                               skilled: skilled,
@@ -112,7 +111,7 @@ class Slot < ApplicationRecord
       result << sub_result
     end
     # tri ordre alphabétique du status (assigned < available < not available < on duty)
-    result.sort_by!{ |h| h.values[0][:status] }
+    result.sort_by!{ |h| [h.values[0][:status].to_s, h.values[0][:skilled].to_s]  }
     return result
   end
 

--- a/app/views/algo_stats/show_statistics_algo.html.erb
+++ b/app/views/algo_stats/show_statistics_algo.html.erb
@@ -4,7 +4,7 @@
 </div>
 <div class="row">
   <div class="statistics-header accordion">
-    <h1>Statistiques générales</h1>
+    <h3>Statistiques générales</h3>
   </div>
   <div class="panel">
   <br>

--- a/app/views/solution_slots/_edit_content.html.erb
+++ b/app/views/solution_slots/_edit_content.html.erb
@@ -1,0 +1,50 @@
+<% locals[:users].each do |hash| %>
+  <!-- set specific class for assigned user row -->
+  <% if User.find(hash.keys.first) == @assigned_user  %>
+    <div class="row assigned-user-row">
+  <!-- set specific class if available and skilled -->
+  <% elsif hash.values.first[:skilled] == "a" && hash.values.first[:status] == "available" %>
+    <div class="row potential-backup">
+  <% elsif hash.values.first[:status] == "available" %>
+    <div class="row available-unskilled">
+  <% else %>
+    <div class="row row-user">
+  <% end %>
+    <div class="col-xs-2">
+     <%= profile_picture(User.find(hash.keys.first)) %>
+    </div>
+    <div class="col-xs-2">
+      <% if hash.values.first[:skilled] == "a" %>
+        <i class="fa fa-check-circle" style="color: green;"></i>
+      <% else %>
+        <i class="fa fa-exclamation-triangle"></i>
+      <% end %>
+    </div>
+    <div class="col-xs-2" >
+      <!-- button -->
+      <%= hash.values.first[:status] %>
+    </div>
+    <div class="col-xs-2">
+      <!-- nb hours day -->
+      <% if hash.values.first[:nb_hours_day_status] == false %>
+        <i class="fa fa-exclamation-triangle"></i><br>
+      <% end %>
+      <%= hash.values.first[:nb_hours_day] %>
+    </div>
+    <div class="col-xs-2">
+      <!-- nb hours week -->
+      <% if hash.values.first[:nb_hours_planning_status] == false %>
+        <i class="fa fa-exclamation-triangle"></i><br>
+      <% end %>
+      <%= hash.values.first[:nb_hours_planning] %>
+    </div>
+    <div class="col-xs-2">
+      <!-- reassign -->
+      <% unless User.find(hash.keys.first) == @assigned_user  %>
+        <%= link_to "assign", planning_solution_slot_path(@planning, @solution_slot, user_id: User.find(hash.keys.first).id, format: :js), method: :patch, remote: true, class: "mybtn mybtn--medium reassign-solution_slot" %>
+      <% end %>
+
+
+    </div>
+  </div>
+<% end %>

--- a/app/views/solution_slots/_edit_content.html.erb
+++ b/app/views/solution_slots/_edit_content.html.erb
@@ -1,14 +1,14 @@
 <% locals[:users].each do |hash| %>
   <!-- set specific class for assigned user row -->
   <% if User.find(hash.keys.first) == @assigned_user  %>
-    <div class="row assigned-user-row">
+    <div class="row assigned-user-row mb-">
   <!-- set specific class if available and skilled -->
   <% elsif hash.values.first[:skilled] == "a" && hash.values.first[:status] == "available" %>
-    <div class="row potential-backup">
+    <div class="row potential-backup mb-">
   <% elsif hash.values.first[:status] == "available" %>
-    <div class="row available-unskilled">
+    <div class="row available-unskilled mb-">
   <% else %>
-    <div class="row row-user">
+    <div class="row row-user mb-">
   <% end %>
     <div class="col-xs-2">
      <%= profile_picture(User.find(hash.keys.first)) %>

--- a/app/views/solution_slots/_edit_header.html.erb
+++ b/app/views/solution_slots/_edit_header.html.erb
@@ -1,0 +1,20 @@
+<div class="row">
+  <div class="col-xs-2">
+    <b>User</b>
+  </div>
+  <div class="col-xs-2">
+    <b>Skilled?</b>
+  </div>
+  <div class="col-xs-2">
+    <b>Status</b>
+  </div>
+  <div class="col-xs-2">
+    <b>h/day</b>
+  </div>
+  <div class="col-xs-2">
+    <b>h/week</b>
+  </div>
+  <div class="col-xs-2">
+    <b></b>
+  </div>
+</div>

--- a/app/views/solution_slots/edit.html.erb
+++ b/app/views/solution_slots/edit.html.erb
@@ -4,81 +4,30 @@
     <div class="row">
       <div class="col-xs-12">
         <!-- creation du tableau -->
+        <b>Employés de l'équipe</b>
         <div class="col-xs-12">
         <!-- en-têtes -->
-          <div class="row">
-            <div class="col-xs-2">
-              <b>User</b>
-            </div>
-            <div class="col-xs-2">
-              <b>Skilled?</b>
-            </div>
-            <div class="col-xs-2">
-              <b>Status</b>
-            </div>
-            <div class="col-xs-2">
-              <b>h/day</b>
-            </div>
-            <div class="col-xs-2">
-              <b>h/week</b>
-            </div>
-            <div class="col-xs-2">
-              <b></b>
-            </div>
-          </div>
-
-          <% @users_infos.each do |hash| %>
-            <!-- set specific class for assigned user row -->
-            <% if User.find(hash.keys.first) == @assigned_user  %>
-              <div class="row assigned-user-row">
-            <!-- set specific class if available and skilled -->
-            <% elsif hash.values.first[:skilled] == true && hash.values.first[:status] == "available" %>
-              <div class="row potential-backup">
-            <% elsif hash.values.first[:status] == "available" %>
-              <div class="row available-unskilled">
-            <% else %>
-              <div class="row row-user">
-            <% end %>
-              <div class="col-xs-2">
-               <%= profile_picture(User.find(hash.keys.first)) %>
-              </div>
-              <div class="col-xs-2">
-                <% if hash.values.first[:skilled] == true %>
-                  <i class="fa fa-check-circle" style="color: green;"></i>
-                <% else %>
-                  <i class="fa fa-exclamation-triangle"></i>
-                <% end %>
-              </div>
-              <div class="col-xs-2" >
-                <!-- button -->
-                <%= hash.values.first[:status] %>
-              </div>
-              <div class="col-xs-2">
-                <!-- nb hours day -->
-                <% if hash.values.first[:nb_hours_day_status] == false %>
-                  <i class="fa fa-exclamation-triangle"></i><br>
-                <% end %>
-                <%= hash.values.first[:nb_hours_day] %>
-              </div>
-              <div class="col-xs-2">
-                <!-- nb hours week -->
-                <% if hash.values.first[:nb_hours_planning_status] == false %>
-                  <i class="fa fa-exclamation-triangle"></i><br>
-                <% end %>
-                <%= hash.values.first[:nb_hours_planning] %>
-              </div>
-              <div class="col-xs-2">
-                <!-- reassign -->
-                <% unless User.find(hash.keys.first) == @assigned_user  %>
-                  <%= link_to "assign", planning_solution_slot_path(@planning, @solution_slot, user_id: User.find(hash.keys.first).id, format: :js), method: :patch, remote: true, class: "mybtn mybtn--medium reassign-solution_slot" %>
-                <% end %>
-
-
-              </div>
-            </div>
-          <% end %>
+        <%= render 'solution_slots/edit_header'%>
+        <!-- block avec chaque user -->
+        <%= render 'solution_slots/edit_content', locals: { users: @users_infos, assigned_user: @assigned_user, planning: @planning, solution_slot: @solution_slot } %>
         </div>
+      </div>
+    </div>
 
+
+    <!-- Liste des employés non sélectionnés dans l'équipe -->
+    <div data-toggle="collapse" data-target="#demo"><b>Employés hors équipe</b></div>
+    <div id="demo" class="collapse">
+      <div class="row">
+        <div class="col-xs-12">
+          <!-- creation du tableau -->
+          <div class="col-xs-12">
+          <!-- en-têtes -->
+          <%= render 'solution_slots/edit_header'%>
+          <!-- block avec chaque user -->
+          <%= render 'solution_slots/edit_content', locals: { users: @other_users_infos, assigned_user: @assigned_user, planning: @planning, solution_slot: @solution_slot  } %>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/app/views/solution_slots/edit.html.erb
+++ b/app/views/solution_slots/edit.html.erb
@@ -18,7 +18,8 @@
       </div>
     </div>
 
-    <!-- Liste des employés non sélectionnés dans l'équipe -->
+    <!-- Liste des employés non sélectionnés dans l'équipe SSI pas de solution dans l'équipe -->
+    <% if !@are_there_backups %>
     <div data-toggle="collapse" data-target="#other-users" class="section-header part2 mb mt">
       <b>Hors équipe</b>
     </div>
@@ -35,6 +36,7 @@
         </div>
       </div>
     </div>
+  <% end %>
 
  <% end %>
 

--- a/app/views/solution_slots/edit.html.erb
+++ b/app/views/solution_slots/edit.html.erb
@@ -1,23 +1,28 @@
 <%= simple_form_for [@planning, @solution_slot] do |f| %>
   <%= f.error_notification %>
 
-    <div class="row">
-      <div class="col-xs-12">
-        <!-- creation du tableau -->
-        <b>Employés de l'équipe</b>
+    <!-- Liste des employés de l'équipe -->
+    <div data-toggle="collapse" data-target="#users" class="section-header part1 mb mt">
+      <b>Equipe</b>
+    </div>
+    <div id="users" class="part1-content collapse">
+      <div class="row">
         <div class="col-xs-12">
-        <!-- en-têtes -->
-        <%= render 'solution_slots/edit_header'%>
-        <!-- block avec chaque user -->
-        <%= render 'solution_slots/edit_content', locals: { users: @users_infos, assigned_user: @assigned_user, planning: @planning, solution_slot: @solution_slot } %>
+          <div class="col-xs-12">
+            <!-- en-têtes -->
+            <%= render 'solution_slots/edit_header'%>
+            <!-- block avec chaque user -->
+            <%= render 'solution_slots/edit_content', locals: { users: @users_infos, assigned_user: @assigned_user, planning: @planning, solution_slot: @solution_slot } %>
+          </div>
         </div>
       </div>
     </div>
 
-
     <!-- Liste des employés non sélectionnés dans l'équipe -->
-    <div data-toggle="collapse" data-target="#demo"><b>Employés hors équipe</b></div>
-    <div id="demo" class="collapse">
+    <div data-toggle="collapse" data-target="#other-users" class="section-header part2 mb mt">
+      <b>Hors équipe</b>
+    </div>
+    <div id="other-users" class="collapse">
       <div class="row">
         <div class="col-xs-12">
           <!-- creation du tableau -->
@@ -32,3 +37,13 @@
     </div>
 
  <% end %>
+
+<script>
+  var a = document.getElementsByClassName("part1-content");
+  a[0].classList.add('in');
+  // reajust the modal's position if its height changes
+  $('.section-header').onclick = function(){
+    $('.modal-reassignment').modal('handleUpdate');
+    console.log("on fait un reajustement");
+  };
+</script>


### PR DESCRIPTION
### Permettre d'afficher les backups potentiels qui ne sont pas dans la team du planning.

modal-reassignment contenue dans /conflicts

![liste des workers autres possibilites](https://user-images.githubusercontent.com/29304869/50694918-785d3500-103b-11e9-94ed-6013b5d5bfa2.gif)

=> les users sont triés par available et ensuite par skilled. Ainsi on a en haut de la liste les available + skilled.
=> on affiche les potentiels backupds possibles qui ne font pas partie de l'équipe mais sont dispos et skilled.
=> dans le cas où dans la liste des users de l'équipe, on a une autre possibilité (skilled + available), on n'affiche pas les backups qui sont en dehors de la team.


Next step --> un peu de front pour mettre un scroll à l'intérieur de la modal... j'ai essayé mais je donne ma langue au chat ;)

